### PR TITLE
Remove auto-refresh from docker compose top view

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -370,3 +370,17 @@ func (c *ComposeClient) parseDindPSJSON(output []byte) ([]models.Container, erro
 
 	return containers, nil
 }
+
+func (c *ComposeClient) GetContainerTop(serviceName string) (string, error) {
+	cmd := exec.Command("docker", "compose", "top", serviceName)
+	if c.workDir != "" {
+		cmd.Dir = c.workDir
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute docker compose top: %w\nOutput: %s", err, string(output))
+	}
+
+	return string(output), nil
+}

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -13,8 +13,6 @@ import (
 	"github.com/tokuhirom/dcv/internal/docker"
 )
 
-// Removed unused tickCmd and tickMsg
-
 // logReader manages log streaming from a container
 type logReader struct {
 	client        *docker.ComposeClient

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -13,6 +13,7 @@ const (
 	ProcessListView ViewType = iota
 	LogView
 	DindProcessListView
+	TopView
 )
 
 // Model represents the application state
@@ -38,6 +39,10 @@ type Model struct {
 	containerName  string
 	isDindLog      bool
 	hostContainer  string
+
+	// Top view state
+	topOutput    string
+	topService   string
 
 	// Search state
 	searchMode bool
@@ -98,6 +103,11 @@ type commandExecutedMsg struct {
 	command string
 }
 
+type topLoadedMsg struct {
+	output string
+	err    error
+}
+
 // Commands
 
 func loadProcesses(client *docker.ComposeClient) tea.Cmd {
@@ -122,4 +132,14 @@ func loadDindContainers(client *docker.ComposeClient, containerName string) tea.
 
 func streamLogs(client *docker.ComposeClient, containerName string, isDind bool, hostContainer string) tea.Cmd {
 	return streamLogsReal(client, containerName, isDind, hostContainer)
+}
+
+func loadTop(client *docker.ComposeClient, serviceName string) tea.Cmd {
+	return func() tea.Msg {
+		output, err := client.GetContainerTop(serviceName)
+		return topLoadedMsg{
+			output: output,
+			err:    err,
+		}
+	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -11,39 +11,39 @@ import (
 // Styles
 var (
 	titleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("86")).
-			MarginBottom(1)
+		Bold(true).
+		Foreground(lipgloss.Color("86")).
+		MarginBottom(1)
 
 	selectedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("86")).
-			Background(lipgloss.Color("235"))
+		Foreground(lipgloss.Color("86")).
+		Background(lipgloss.Color("235"))
 
 	normalStyle = lipgloss.NewStyle()
 
 	errorStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196")).
-			Bold(true)
+		Foreground(lipgloss.Color("196")).
+		Bold(true)
 
 	helpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("241"))
+		Foreground(lipgloss.Color("241"))
 
 	headerStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("226"))
+		Bold(true).
+		Foreground(lipgloss.Color("226"))
 
 	dindStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("42"))
+		Foreground(lipgloss.Color("42"))
 
 	statusUpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("42"))
+		Foreground(lipgloss.Color("42"))
 
 	statusDownStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196"))
+		Foreground(lipgloss.Color("196"))
 
 	searchStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("226")).
-			Bold(true)
+		Foreground(lipgloss.Color("226")).
+		Bold(true)
 )
 
 // View returns the view for the current model
@@ -59,6 +59,8 @@ func (m Model) View() string {
 		return m.renderLogView()
 	case DindProcessListView:
 		return m.renderDindList()
+	case TopView:
+		return m.renderTopView()
 	default:
 		return "Unknown view"
 	}
@@ -266,6 +268,52 @@ func (m Model) renderDindList() string {
 	// Show last command if available
 	if m.lastCommand != "" {
 		s.WriteString("\n" + helpStyle.Render(fmt.Sprintf("Last command: %s", m.lastCommand)))
+	}
+
+	return s.String()
+}
+
+func (m Model) renderTopView() string {
+	var s strings.Builder
+
+	title := titleStyle.Render(fmt.Sprintf("Process Info: %s", m.topService))
+	s.WriteString(title + "\n\n")
+
+	if m.err != nil {
+		s.WriteString(errorStyle.Render(fmt.Sprintf("Error: %v", m.err)) + "\n")
+		s.WriteString("\n" + helpStyle.Render("Press 'Esc' to go back, 'q' to quit"))
+		return s.String()
+	}
+
+	if m.loading {
+		s.WriteString("Loading process information...")
+		return s.String()
+	}
+
+	// Display the top output
+	if m.topOutput != "" {
+		s.WriteString(m.topOutput)
+	} else {
+		s.WriteString("No process information available\n")
+	}
+
+	// Fill remaining space
+	outputLines := strings.Count(m.topOutput, "\n")
+	viewHeight := m.height - 5
+	if m.lastCommand != "" {
+		viewHeight--
+	}
+	for i := outputLines; i < viewHeight; i++ {
+		s.WriteString("\n")
+	}
+
+	// Help text
+	help := helpStyle.Render("r: refresh • Esc/q: back")
+	s.WriteString(help)
+
+	// Show last command if available
+	if m.lastCommand != "" {
+		s.WriteString("\n" + helpStyle.Render(fmt.Sprintf("Command: %s", m.lastCommand)))
 	}
 
 	return s.String()


### PR DESCRIPTION
Since `docker compose top` shows a static snapshot of processes (unlike `docker stats`), auto-refresh is unnecessary. The view now only refreshes manually with the 'r' key.

Changes:
- Removed tick command integration from top view
- Removed tickCmd and tickMsg as they are no longer used
- Updated help text to remove "Auto-refresh: 1s" indicator
- Top view still accessible with 't' key from process list
- Manual refresh still available with 'r' key