### PR TITLE
Fix incorrect content in README-test.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,22 +12,41 @@ DCV (Docker Compose Viewer) is a TUI tool for monitoring Docker Compose applicat
 ## Technical Architecture
 
 - **Language**: Go (Golang)
-- **TUI Framework**: tview
+- **TUI Framework**: Bubble Tea (with Lipgloss for styling)
+- **Architecture**: Model-View-Update (MVU) pattern
 - **Core Functionality**: Wraps docker-compose commands to provide an interactive interface
 
 ## Key Views
 
 1. **Process List View**: Shows `docker compose ps` results
-   - Enter: View container logs
-   - d: Treat as dind container and navigate to dind process list
+   - `↑`/`k`: Move up
+   - `↓`/`j`: Move down
+   - `Enter`: View container logs
+   - `d`: Navigate to dind process list (for dind containers)
+   - `t`: Show process info (docker compose top)
+   - `K`: Kill service (docker compose kill)
+   - `S`: Stop service (docker compose stop)
+   - `r`: Refresh list
+   - `q`: Quit
 
 2. **Dind Process List View**: Executes `docker ps` inside selected dind containers
-   - Enter: View logs of containers running inside dind
+   - `↑`/`k`: Move up
+   - `↓`/`j`: Move down
+   - `Enter`: View logs of containers running inside dind
+   - `r`: Refresh list
+   - `Esc`/`q`: Back to process list
 
 3. **Log View**: Displays container logs with vim-like navigation
-   - `/`: Search functionality
+   - `↑`/`k`: Scroll up
+   - `↓`/`j`: Scroll down
    - `G`: Jump to end
-   - Standard vim navigation keys
+   - `g`: Jump to start
+   - `/`: Search functionality
+   - `Esc`/`q`: Back to previous view
+
+4. **Top View**: Shows process information (docker compose top)
+   - `r`: Refresh
+   - `Esc`/`q`: Back to process list
 
 ## Development Guidelines
 
@@ -37,7 +56,15 @@ DCV (Docker Compose Viewer) is a TUI tool for monitoring Docker Compose applicat
 
 ## Build and Installation
 
-The project is intended to be installed via `go install` (implementation pending).
+```bash
+# Install via go install
+go install github.com/tokuhirom/dcv@latest
+
+# Or build from source
+git clone https://github.com/tokuhirom/dcv.git
+cd dcv
+go build -o dcv
+```
 
 ## License
 

--- a/README-test.md
+++ b/README-test.md
@@ -43,7 +43,21 @@ The docker-compose.yml sets up:
 ## Testing DCV Features
 
 1. **View all containers**: The main screen shows all docker-compose services
-2. **View logs**: Press Enter on any container to see its logs
-3. **Dind support**: Press 'd' on the dind container to see containers running inside it
-4. **Vim navigation**: Use j/k to navigate, G to go to end, / to search in logs
-5. **Exit**: Press 'q' or Esc to go back/quit
+2. **View logs**: Press Enter on any container to see its logs (initial 1000 lines + real-time streaming)
+3. **Process info**: Press 't' to view process information (docker compose top)
+4. **Container management**: 
+   - Press 'K' (capital K) to kill a service
+   - Press 'S' (capital S) to stop a service
+5. **Dind support**: Press 'd' on the dind container to see containers running inside it
+6. **Vim navigation**: 
+   - Use j/k or ↑/↓ to navigate
+   - In logs: G to go to end, g to go to start
+   - / to search in logs
+7. **Refresh**: Press 'r' to refresh the current view
+8. **Exit**: Press 'q' to quit, or Esc to go back to previous view
+
+## Debug Features
+
+- The last executed docker command is displayed at the bottom of the screen
+- Error messages include detailed command output for troubleshooting
+- STDERR output is prefixed with `[STDERR]` in log views


### PR DESCRIPTION
## Summary
Fixed outdated and incorrect content in documentation files as reported in #8

## Changes

### CLAUDE.md
- Changed TUI framework reference from `tview` to `Bubble Tea` (with Lipgloss)
- Added MVU architecture pattern mention
- Updated all key bindings to reflect current features:
  - Added top view (t key)
  - Added kill (K) and stop (S) commands
  - Documented all navigation keys for each view
- Added proper build and installation instructions

### README-test.md
- Updated feature list to include all current functionality
- Added process info view documentation
- Added container management commands (K for kill, S for stop)
- Added debug features section
- Updated navigation instructions to match current implementation

## Test plan
- [x] Reviewed all key bindings against current implementation
- [x] Verified feature descriptions match actual functionality
- [x] Cross-referenced with main README.md for consistency

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)