### PR TITLE
Add docker compose restart and start commands

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -413,6 +413,34 @@ func (c *ComposeClient) StopService(serviceName string) error {
 	return nil
 }
 
+func (c *ComposeClient) StartService(serviceName string) error {
+	cmd := exec.Command("docker", "compose", "start", serviceName)
+	if c.workDir != "" {
+		cmd.Dir = c.workDir
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to execute docker compose start: %w\nOutput: %s", err, string(output))
+	}
+
+	return nil
+}
+
+func (c *ComposeClient) RestartService(serviceName string) error {
+	cmd := exec.Command("docker", "compose", "restart", serviceName)
+	if c.workDir != "" {
+		cmd.Dir = c.workDir
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to execute docker compose restart: %w\nOutput: %s", err, string(output))
+	}
+
+	return nil
+}
+
 func (c *ComposeClient) GetStats() (string, error) {
 	cmd := exec.Command("docker", "compose", "stats", "--format", "json", "--no-stream", "--all")
 	if c.workDir != "" {

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -218,3 +218,29 @@ func TestGetStats(t *testing.T) {
 	// Either error or empty result is acceptable
 	_ = err
 }
+
+func TestStartService(t *testing.T) {
+	// This is a basic test that just checks the method exists
+	// In a real test environment, you would mock the exec.Command
+	client := NewComposeClient("")
+	
+	// We can't actually test starting a service without a stopped container
+	// So we just verify the method exists and returns an error for non-existent service
+	err := client.StartService("non-existent-service")
+	if err == nil {
+		t.Error("Expected error for non-existent service, got nil")
+	}
+}
+
+func TestRestartService(t *testing.T) {
+	// This is a basic test that just checks the method exists
+	// In a real test environment, you would mock the exec.Command
+	client := NewComposeClient("")
+	
+	// We can't actually test restarting a service without a running container
+	// So we just verify the method exists and returns an error for non-existent service
+	err := client.RestartService("non-existent-service")
+	if err == nil {
+		t.Error("Expected error for non-existent service, got nil")
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -198,6 +198,28 @@ func stopService(client *docker.ComposeClient, serviceName string) tea.Cmd {
 	}
 }
 
+func startService(client *docker.ComposeClient, serviceName string) tea.Cmd {
+	return func() tea.Msg {
+		err := client.StartService(serviceName)
+		return serviceActionCompleteMsg{
+			action: "start",
+			service: serviceName,
+			err:    err,
+		}
+	}
+}
+
+func restartService(client *docker.ComposeClient, serviceName string) tea.Cmd {
+	return func() tea.Msg {
+		err := client.RestartService(serviceName)
+		return serviceActionCompleteMsg{
+			action: "restart",
+			service: serviceName,
+			err:    err,
+		}
+	}
+}
+
 func loadStats(client *docker.ComposeClient) tea.Cmd {
 	return func() tea.Msg {
 		output, err := client.GetStats()

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -210,6 +210,22 @@ func (m Model) handleProcessListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case "U": // Capital U for start (up)
+		if m.selectedProcess < len(m.processes) {
+			process := m.processes[m.selectedProcess]
+			m.loading = true
+			return m, startService(m.dockerClient, process.Service)
+		}
+		return m, nil
+
+	case "R": // Capital R for restart
+		if m.selectedProcess < len(m.processes) {
+			process := m.processes[m.selectedProcess]
+			m.loading = true
+			return m, restartService(m.dockerClient, process.Service)
+		}
+		return m, nil
+
 	default:
 		return m, nil
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -149,8 +149,11 @@ func (m Model) renderProcessList() string {
 	s.WriteString(t.Render() + "\n\n")
 
 	// Help text
-	help := helpStyle.Render("↑/k: up • ↓/j: down • Enter: logs • d: dind • s: stats • t: top • K: kill • S: stop • r: refresh • q: quit")
-	s.WriteString(help)
+	help := []string{
+		"↑/k: up • ↓/j: down • Enter: logs • d: dind • s: stats • t: top",
+		"K: kill • S: stop • U: start • R: restart • r: refresh • q: quit",
+	}
+	s.WriteString(helpStyle.Render(strings.Join(help, "\n")))
 
 	// Show last command if available
 	if m.lastCommand != "" {


### PR DESCRIPTION
## Summary
Added `docker compose restart` and `docker compose start` commands to the process list view, completing the container lifecycle management capabilities.

## Features
- Press 'R' (capital R) to restart a service
- Press 'U' (capital U) to start a stopped service
- Help text now displays on two lines for better readability

## Container lifecycle commands
The process list view now supports the full container lifecycle:
- **U**: start (bring up a stopped container)
- **S**: stop (gracefully stop a container)  
- **R**: restart (restart a running container)
- **K**: kill (forcefully stop a container)

## Implementation details
- Added `RestartService` method to ComposeClient
- Added `StartService` method to ComposeClient  
- Added corresponding command functions in the model
- Process list automatically refreshes after each action
- Error handling included for all operations

## Test plan
- [x] Press 'R' on a running container to restart it
- [x] Press 'U' on a stopped container to start it
- [x] Verify the process list refreshes after each operation
- [x] Verify error handling for non-existent services
- [x] Run tests with `go test ./...`

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)