### PR TITLE
Add multi-project support

### DIFF
--- a/internal/docker/compose_project_test.go
+++ b/internal/docker/compose_project_test.go
@@ -1,0 +1,69 @@
+package docker
+
+import (
+	"testing"
+)
+
+func TestBuildComposeArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      *ComposeClient
+		baseArgs    []string
+		expected    []string
+	}{
+		{
+			name: "no project or file",
+			client: &ComposeClient{},
+			baseArgs: []string{"ps"},
+			expected: []string{"compose", "ps"},
+		},
+		{
+			name: "with project name",
+			client: &ComposeClient{projectName: "myproject"},
+			baseArgs: []string{"ps"},
+			expected: []string{"compose", "-p", "myproject", "ps"},
+		},
+		{
+			name: "with compose file",
+			client: &ComposeClient{composeFile: "docker-compose.prod.yml"},
+			baseArgs: []string{"ps"},
+			expected: []string{"compose", "-f", "docker-compose.prod.yml", "ps"},
+		},
+		{
+			name: "with both project and file",
+			client: &ComposeClient{
+				projectName: "myproject",
+				composeFile: "docker-compose.prod.yml",
+			},
+			baseArgs: []string{"ps", "--all"},
+			expected: []string{"compose", "-p", "myproject", "-f", "docker-compose.prod.yml", "ps", "--all"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.buildComposeArgs(tt.baseArgs...)
+			if len(result) != len(tt.expected) {
+				t.Errorf("buildComposeArgs() returned %d args, expected %d", len(result), len(tt.expected))
+				return
+			}
+			for i, arg := range result {
+				if arg != tt.expected[i] {
+					t.Errorf("buildComposeArgs()[%d] = %s, expected %s", i, arg, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestListProjects(t *testing.T) {
+	// This is a basic test that just checks the method exists
+	// In a real test environment, you would mock the exec.Command
+	client := NewComposeClient("")
+	
+	// We can't actually test listing projects without docker compose
+	// The method should return an error or empty result
+	_, err := client.ListProjects()
+	// Either error or empty result is acceptable
+	_ = err
+}

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -1,0 +1,8 @@
+package models
+
+// ComposeProject represents a Docker Compose project
+type ComposeProject struct {
+	Name       string `json:"Name"`
+	Status     string `json:"Status"`
+	ConfigFiles string `json:"ConfigFiles"`
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -9,8 +10,15 @@ import (
 )
 
 func main() {
-	// Create the initial model
-	m := ui.NewModel()
+	// Parse command-line flags
+	var projectName string
+	var composeFile string
+	flag.StringVar(&projectName, "p", "", "Specify project name")
+	flag.StringVar(&composeFile, "f", "", "Specify compose file")
+	flag.Parse()
+
+	// Create the initial model with options
+	m := ui.NewModelWithOptions(projectName, composeFile)
 
 	// Create the program
 	p := tea.NewProgram(m, tea.WithAltScreen())


### PR DESCRIPTION
## Summary
- Adds command-line flags `-p` for project name and `-f` for compose file
- Implements docker compose ls view to show all projects when no compose file exists
- Auto-switches to project list view when no docker-compose.yml is found

## Features
1. **Project List View**: When no docker-compose.yml file exists in the current directory, dcv now shows a list of all running Docker Compose projects (using `docker compose ls`)
2. **Project Selection**: Users can navigate the project list and select a project to view its containers
3. **Command-line Options**:
   - `-p PROJECT_NAME`: Specify a project name to connect to
   - `-f COMPOSE_FILE`: Specify an alternative compose file path
4. **Enhanced UI**: The process list view now shows the active project name and compose file in the title

## Test Plan
- [x] Test without docker-compose.yml to see project list
- [x] Test with -p flag to specify project name
- [x] Test with -f flag to use alternative compose file
- [x] Verify all existing functionality still works
- [x] Run unit tests

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)