### PR TITLE
Add verbose logger container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,25 @@ services:
     entrypoint: ["/entrypoint.sh"]
     command: ["dockerd", "--host=unix:///var/run/docker.sock", "--host=tcp://0.0.0.0:2375"]
 
+  # Verbose logger container that outputs messages periodically
+  logger:
+    image: alpine:latest
+    command: |
+      sh -c "
+        counter=1
+        while true; do
+          echo \"[$(date '+%Y-%m-%d %H:%M:%S')] Logger message #$$counter: Hello from verbose container!\"
+          echo \"[$(date '+%Y-%m-%d %H:%M:%S')] System info: $(uname -a)\"
+          echo \"[$(date '+%Y-%m-%d %H:%M:%S')] Memory usage: $(free -h | grep Mem | awk '{print $$3 \"/\" $$2}')\"
+          echo \"[$(date '+%Y-%m-%d %H:%M:%S')] Random data: $(head -c 32 /dev/urandom | base64)\"
+          echo \"----------------------------------------\"
+          counter=$$((counter + 1))
+          sleep 2
+        done
+      "
+    networks:
+      - dcv-network
+
 volumes:
   postgres-data:
   redis-data:


### PR DESCRIPTION
## Summary
- Adds a verbose logger container that outputs messages periodically to stdout
- Outputs messages every 2 seconds with timestamps and various information
- Useful for testing log viewing functionality in dcv

## Logger Output
The logger container outputs:
- Timestamp for each log entry
- Message counter
- System information (uname -a)
- Memory usage information
- Random base64 data for variety
- Separator lines between entries

## Example Output
```
[2025-07-31 14:56:08] Logger message #1: Hello from verbose container\!
[2025-07-31 14:56:08] System info: Linux 5a2eda5f4ff0 6.10.14-linuxkit #1 SMP Sat May 17 08:28:57 UTC 2025 aarch64 Linux
[2025-07-31 14:56:08] Memory usage: 2.6G/7.7G
[2025-07-31 14:56:08] Random data: +DGcZLlKZjMKHws4rOEuuyIhwTH6H8M84q672uizeNE=
----------------------------------------
```

## Test Plan
- [x] Start the logger container with `docker compose up -d logger`
- [x] Check logs with `docker compose logs logger`
- [x] Verify messages appear every 2 seconds
- [x] Test viewing logs in dcv

Fixes #17

🤖 Generated with [Claude Code](https://claude.ai/code)