### PR TITLE
Fix dind view to use service name instead of container name

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -56,7 +56,8 @@ type Model struct {
 	// Dind state
 	dindContainers       []models.Container
 	selectedDindContainer int
-	currentDindHost      string
+	currentDindHost      string  // Container name (for display)
+	currentDindService   string  // Service name (for docker compose exec)
 
 	// Log view state
 	logs           []string

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -47,7 +47,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case dindContainersLoadedMsg:
 		m.loading = false
-		m.lastCommand = fmt.Sprintf("docker compose exec -T %s docker ps --format json", m.currentDindHost)
+		m.lastCommand = fmt.Sprintf("docker compose exec -T %s docker ps --format json", m.currentDindService)
 		if msg.err != nil {
 			m.err = msg.err
 			return m, nil
@@ -201,9 +201,10 @@ func (m Model) handleProcessListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			process := m.processes[m.selectedProcess]
 			if process.IsDind {
 				m.currentDindHost = process.Name
+				m.currentDindService = process.Service
 				m.currentView = DindProcessListView
 				m.loading = true
-				return m, loadDindContainers(m.dockerClient, process.Name)
+				return m, loadDindContainers(m.dockerClient, process.Service)
 			}
 		}
 		return m, nil
@@ -275,7 +276,7 @@ func (m Model) handleLogViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		if m.isDindLog {
 			m.currentView = DindProcessListView
-			return m, loadDindContainers(m.dockerClient, m.currentDindHost)
+			return m, loadDindContainers(m.dockerClient, m.currentDindService)
 		}
 		m.currentView = ProcessListView
 		return m, loadProcesses(m.dockerClient, m.showAll)
@@ -337,7 +338,7 @@ func (m Model) handleDindListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.currentView = LogView
 			m.logs = []string{}
 			m.logScrollY = 0
-			return m, streamLogs(m.dockerClient, container.Name, true, m.currentDindHost)
+			return m, streamLogs(m.dockerClient, container.Name, true, m.currentDindService)
 		}
 		return m, nil
 
@@ -347,7 +348,7 @@ func (m Model) handleDindListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "r":
 		m.loading = true
-		return m, loadDindContainers(m.dockerClient, m.currentDindHost)
+		return m, loadDindContainers(m.dockerClient, m.currentDindService)
 
 	default:
 		return m, nil


### PR DESCRIPTION
## Summary
- Fixes the issue where docker compose exec was using container name instead of service name
- Adds separate field to store service name for docker compose exec commands
- Keeps container name for display purposes

## Problem
When viewing Docker-in-Docker containers, the command was incorrectly using:
```bash
docker compose exec -T dcv-dind-1 docker ps
```

But it should use the service name:
```bash
docker compose exec -T dind docker ps
```

## Solution
- Added `currentDindService` field to store the service name
- Updated all `docker compose exec` commands to use the service name
- Kept `currentDindHost` for display purposes (shows container name in UI)

## Test Plan
- [x] Test dind view with running dind container
- [x] Verify docker compose exec commands use service name
- [x] Ensure display still shows container name
- [x] Run unit tests

🤖 Generated with [Claude Code](https://claude.ai/code)