### PR TITLE
Add shortcut key to display project list

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -266,6 +266,12 @@ func (m Model) handleProcessListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case "p": // Show project list
+		m.currentView = ProjectListView
+		m.showProjectList = true
+		m.loading = true
+		return m, loadProjects(m.dockerClient)
+
 	default:
 		return m, nil
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -161,7 +161,7 @@ func (m Model) renderProcessList() string {
 
 	// Help text
 	help := []string{
-		"↑/k: up • ↓/j: down • Enter: logs • d: dind • s: stats • t: top • a: toggle all",
+		"↑/k: up • ↓/j: down • Enter: logs • d: dind • s: stats • t: top • a: toggle all • p: projects",
 		"K: kill • S: stop • U: start • R: restart • r: refresh • q: quit",
 	}
 	s.WriteString(helpStyle.Render(strings.Join(help, "\n")))


### PR DESCRIPTION
## Summary
- Adds 'p' shortcut key to display the project list from the process list view
- Updates help text to show the new shortcut

## Features
- **Quick project switching**: Press 'p' from the process list view to show all Docker Compose projects
- **Seamless navigation**: Switch between different projects without restarting dcv
- **Intuitive key binding**: 'p' for 'projects' is easy to remember

## Usage
1. From the process list view, press 'p'
2. The project list will be displayed showing all running Docker Compose projects
3. Select a project and press Enter to switch to it

## Test Plan
- [x] Test 'p' key from process list view
- [x] Verify project list is displayed
- [x] Check help text shows the new shortcut
- [x] Run unit tests

🤖 Generated with [Claude Code](https://claude.ai/code)