### PR TITLE
Add --projects flag to show project list at startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,12 +13,14 @@ func main() {
 	// Parse command-line flags
 	var projectName string
 	var composeFile string
+	var showProjects bool
 	flag.StringVar(&projectName, "p", "", "Specify project name")
 	flag.StringVar(&composeFile, "f", "", "Specify compose file")
+	flag.BoolVar(&showProjects, "projects", false, "Show project list at startup")
 	flag.Parse()
 
 	// Create the initial model with options
-	m := ui.NewModelWithOptions(projectName, composeFile)
+	m := ui.NewModelWithOptions(projectName, composeFile, showProjects)
 
 	// Create the program
 	p := tea.NewProgram(m, tea.WithAltScreen())


### PR DESCRIPTION
## Summary
- Added `--projects` command line flag to start the application with project list view
- Modified `NewModelWithOptions` to accept `showProjects` parameter and set initial view accordingly
- Added shortcut key 'p' to switch to project list from process list view

## Changes
- `main.go`: Added `--projects` boolean flag
- `internal/ui/model.go`: Updated `NewModelWithOptions` to handle `showProjects` parameter
- `internal/ui/update.go`: Added 'p' key handler in process list view

## Test plan
- [x] Build the application
- [x] Run `dcv --projects` to verify it starts with project list view
- [x] Run `dcv` normally to verify it starts with process list view
- [x] Press 'p' key in process list view to verify switching to project list

🤖 Generated with [Claude Code](https://claude.ai/code)