### PR TITLE
Fix misleading parameter names in docker compose logs

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -252,12 +252,12 @@ func (c *ComposeClient) parseComposePSJSON(output []byte) ([]models.Process, err
 	return processes, nil
 }
 
-func (c *ComposeClient) GetContainerLogs(containerName string, follow bool) (*exec.Cmd, error) {
+func (c *ComposeClient) GetContainerLogs(serviceName string, follow bool) (*exec.Cmd, error) {
 	baseArgs := []string{"logs", "--tail", "1000", "--timestamps"}
 	if follow {
 		baseArgs = append(baseArgs, "-f")
 	}
-	baseArgs = append(baseArgs, containerName)
+	baseArgs = append(baseArgs, serviceName)
 
 	args := c.buildComposeArgs(baseArgs...)
 	cmd := exec.Command("docker", args...)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -193,8 +193,8 @@ func loadDindContainers(client *docker.ComposeClient, containerName string) tea.
 	}
 }
 
-func streamLogs(client *docker.ComposeClient, containerName string, isDind bool, hostContainer string) tea.Cmd {
-	return streamLogsReal(client, containerName, isDind, hostContainer)
+func streamLogs(client *docker.ComposeClient, serviceName string, isDind bool, hostService string) tea.Cmd {
+	return streamLogsReal(client, serviceName, isDind, hostService)
 }
 
 func loadTop(client *docker.ComposeClient, serviceName string) tea.Cmd {


### PR DESCRIPTION
## Summary
- Fixed misleading parameter names in log-related functions
- Renamed `containerName` to `serviceName` to correctly reflect that `docker compose logs` expects SERVICE names, not container names

## Changes
- `internal/docker/compose.go`: Renamed parameter in `GetContainerLogs` from `containerName` to `serviceName`
- `internal/ui/commands.go`: Updated parameter names in `newLogReader` and `streamLogsReal` functions
- `internal/ui/model.go`: Updated parameter names in `streamLogs` function

## Notes
The code was already working correctly (passing service names), but the parameter names were misleading. This change makes the code more readable and self-documenting.

## Test plan
- [x] Build the application successfully
- [x] Verify logs still work correctly for regular containers
- [x] Verify logs still work correctly for dind containers

🤖 Generated with [Claude Code](https://claude.ai/code)