### PR TITLE
Add debug log view to track command history

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/tokuhirom/dcv/internal/models"
 )
@@ -15,6 +16,17 @@ type ComposeClient struct {
 	workDir     string
 	projectName string
 	composeFile string
+	commandLogs []CommandLog
+}
+
+// CommandLog represents a command execution log entry
+type CommandLog struct {
+	Timestamp time.Time
+	Command   string
+	ExitCode  int
+	Output    string
+	Error     string
+	Duration  time.Duration
 }
 
 func NewComposeClient(workDir string) *ComposeClient {
@@ -38,7 +50,7 @@ func (c *ComposeClient) ListProjects() ([]models.ComposeProject, error) {
 		cmd.Dir = c.workDir
 	}
 	
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute docker compose ls: %w\nOutput: %s", err, string(output))
 	}
@@ -67,6 +79,51 @@ func (c *ComposeClient) ListProjects() ([]models.ComposeProject, error) {
 	}
 	
 	return projects, nil
+}
+
+// GetCommandLogs returns the command execution logs
+func (c *ComposeClient) GetCommandLogs() []CommandLog {
+	return c.commandLogs
+}
+
+// executeAndLog executes a command and logs the result
+func (c *ComposeClient) executeAndLog(cmd *exec.Cmd) ([]byte, error) {
+	startTime := time.Now()
+	cmdStr := strings.Join(cmd.Args, " ")
+	
+	output, err := cmd.CombinedOutput()
+	duration := time.Since(startTime)
+	
+	exitCode := 0
+	errorStr := ""
+	
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+		errorStr = err.Error()
+	}
+	
+	// Add to command logs
+	log := CommandLog{
+		Timestamp: startTime,
+		Command:   cmdStr,
+		ExitCode:  exitCode,
+		Output:    string(output),
+		Error:     errorStr,
+		Duration:  duration,
+	}
+	
+	c.commandLogs = append(c.commandLogs, log)
+	
+	// Keep only last 100 commands
+	if len(c.commandLogs) > 100 {
+		c.commandLogs = c.commandLogs[len(c.commandLogs)-100:]
+	}
+	
+	return output, err
 }
 
 // buildComposeArgs builds the docker compose command arguments with project and file options
@@ -98,7 +155,7 @@ func (c *ComposeClient) ListContainers(showAll bool) ([]models.Process, error) {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		// Check if docker compose is available
 		if execErr, ok := err.(*exec.ExitError); ok {
@@ -302,7 +359,7 @@ func (c *ComposeClient) ListDindContainers(containerName string) ([]models.Conta
 		return nil, err
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		// If JSON format fails, try table format
 		cmd, err = c.ExecInContainer(containerName, []string{"docker", "ps"})
@@ -310,7 +367,7 @@ func (c *ComposeClient) ListDindContainers(containerName string) ([]models.Conta
 			return nil, err
 		}
 		
-		output, err = cmd.CombinedOutput()
+		output, err = c.executeAndLog(cmd)
 		if err != nil {
 			// Include the command and output in error message for debugging
 			cmdStr := strings.Join(cmd.Args, " ")
@@ -450,7 +507,7 @@ func (c *ComposeClient) GetContainerTop(serviceName string) (string, error) {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute docker compose top: %w\nOutput: %s", err, string(output))
 	}
@@ -465,7 +522,7 @@ func (c *ComposeClient) KillService(serviceName string) error {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute docker compose kill: %w\nOutput: %s", err, string(output))
 	}
@@ -480,7 +537,7 @@ func (c *ComposeClient) StopService(serviceName string) error {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute docker compose stop: %w\nOutput: %s", err, string(output))
 	}
@@ -495,7 +552,7 @@ func (c *ComposeClient) StartService(serviceName string) error {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute docker compose start: %w\nOutput: %s", err, string(output))
 	}
@@ -510,7 +567,7 @@ func (c *ComposeClient) RestartService(serviceName string) error {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute docker compose restart: %w\nOutput: %s", err, string(output))
 	}
@@ -525,7 +582,7 @@ func (c *ComposeClient) RemoveService(serviceName string) error {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute docker compose rm: %w\nOutput: %s", err, string(output))
 	}
@@ -540,7 +597,7 @@ func (c *ComposeClient) UpService(serviceName string) error {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute docker compose up: %w\nOutput: %s", err, string(output))
 	}
@@ -554,7 +611,7 @@ func (c *ComposeClient) GetStats() (string, error) {
 		cmd.Dir = c.workDir
 	}
 
-	output, err := cmd.CombinedOutput()
+	output, err := c.executeAndLog(cmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute docker compose stats: %w\nOutput: %s", err, string(output))
 	}

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -60,9 +60,15 @@ func newLogReader(client *docker.ComposeClient, serviceName string, isDind bool,
 		return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
 	}
 
+	// Log the command execution
+	startTime := time.Now()
 	if err := lr.cmd.Start(); err != nil {
+		client.LogCommand(lr.cmd, startTime, err)
 		return nil, fmt.Errorf("failed to start log command '%s': %w", strings.Join(lr.cmd.Args, " "), err)
 	}
+	
+	// Log successful start
+	client.LogCommand(lr.cmd, startTime, nil)
 
 	// Start reading logs in background
 	go lr.readLogs()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -75,8 +75,8 @@ type Model struct {
 	stats []ContainerStats
 
 	// Debug log view state
-	commandLogs       []docker.CommandLog // For display
-	sharedCommandLogs []docker.CommandLog // Shared across all docker clients
+	commandLogs       []docker.CommandLog  // For display
+	sharedCommandLogs *[]docker.CommandLog // Shared across all docker clients (pointer)
 	debugLogScrollY   int
 
 	// Search state
@@ -111,7 +111,7 @@ func NewModel() Model {
 		currentView:       ProcessListView,
 		dockerClient:      client,
 		loading:           true,
-		sharedCommandLogs: sharedLogs,
+		sharedCommandLogs: &sharedLogs,
 	}
 }
 
@@ -134,7 +134,7 @@ func NewModelWithOptions(projectName, composeFile string, showProjects bool) Mod
 		projectName:       projectName,
 		composeFile:       composeFile,
 		showProjectList:   showProjects,
-		sharedCommandLogs: sharedLogs,
+		sharedCommandLogs: &sharedLogs,
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -87,6 +87,7 @@ type Model struct {
 
 	// Debug log view state
 	commandLogs       []CommandLog
+	sharedCommandLogs []docker.CommandLog // Shared across all docker clients
 	debugLogScrollY   int
 
 	// Search state
@@ -113,16 +114,23 @@ type Model struct {
 
 // NewModel creates a new model with initial state
 func NewModel() Model {
+	sharedLogs := make([]docker.CommandLog, 0)
+	client := docker.NewComposeClient("")
+	client.SetCommandLogs(&sharedLogs)
+	
 	return Model{
-		currentView:  ProcessListView,
-		dockerClient: docker.NewComposeClient(""),
-		loading:      true,
+		currentView:       ProcessListView,
+		dockerClient:      client,
+		loading:           true,
+		sharedCommandLogs: sharedLogs,
 	}
 }
 
 // NewModelWithOptions creates a new model with command line options
 func NewModelWithOptions(projectName, composeFile string, showProjects bool) Model {
+	sharedLogs := make([]docker.CommandLog, 0)
 	client := docker.NewComposeClientWithOptions("", projectName, composeFile)
+	client.SetCommandLogs(&sharedLogs)
 	
 	// Determine initial view
 	initialView := ProcessListView
@@ -131,12 +139,13 @@ func NewModelWithOptions(projectName, composeFile string, showProjects bool) Mod
 	}
 	
 	return Model{
-		currentView:     initialView,
-		dockerClient:    client,
-		loading:         true,
-		projectName:     projectName,
-		composeFile:     composeFile,
-		showProjectList: showProjects,
+		currentView:       initialView,
+		dockerClient:      client,
+		loading:           true,
+		projectName:       projectName,
+		composeFile:       composeFile,
+		showProjectList:   showProjects,
+		sharedCommandLogs: sharedLogs,
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/tokuhirom/dcv/internal/docker"
@@ -22,16 +21,6 @@ type ContainerStats struct {
 	NetIO       string  `json:"NetIO"`
 	BlockIO     string  `json:"BlockIO"`
 	PIDs        string  `json:"PIDs"`
-}
-
-// CommandLog represents a command execution log entry
-type CommandLog struct {
-	Timestamp time.Time
-	Command   string
-	ExitCode  int
-	Output    string
-	Error     string
-	Duration  time.Duration
 }
 
 // ViewType represents the current view
@@ -86,7 +75,7 @@ type Model struct {
 	stats []ContainerStats
 
 	// Debug log view state
-	commandLogs       []CommandLog
+	commandLogs       []docker.CommandLog // For display
 	sharedCommandLogs []docker.CommandLog // Shared across all docker clients
 	debugLogScrollY   int
 
@@ -213,7 +202,7 @@ type projectsLoadedMsg struct {
 }
 
 type commandLogsMsg struct {
-	logs []CommandLog
+	logs []docker.CommandLog
 }
 
 // Commands
@@ -364,19 +353,8 @@ func loadProjects(client *docker.ComposeClient) tea.Cmd {
 
 func loadCommandLogs(client *docker.ComposeClient) tea.Cmd {
 	return func() tea.Msg {
-		// Convert docker.CommandLog to ui.CommandLog
-		dockerLogs := client.GetCommandLogs()
-		uiLogs := make([]CommandLog, len(dockerLogs))
-		for i, log := range dockerLogs {
-			uiLogs[i] = CommandLog{
-				Timestamp: log.Timestamp,
-				Command:   log.Command,
-				ExitCode:  log.ExitCode,
-				Output:    log.Output,
-				Error:     log.Error,
-				Duration:  log.Duration,
-			}
-		}
-		return commandLogsMsg{logs: uiLogs}
+		// Just return a signal to refresh the view
+		// The actual logs are in m.sharedCommandLogs
+		return commandLogsMsg{logs: nil}
 	}
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -125,6 +125,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case commandLogsMsg:
+		m.loading = false
+		m.commandLogs = msg.logs
+		// Auto-scroll to bottom to show latest commands
+		maxScroll := len(m.commandLogs) - (m.height - 4)
+		if maxScroll > 0 {
+			m.debugLogScrollY = maxScroll
+		}
+		return m, nil
+
 	default:
 		return m, nil
 	}
@@ -164,6 +174,8 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleStatsViewKeys(msg)
 	case ProjectListView:
 		return m.handleProjectListKeys(msg)
+	case DebugLogView:
+		return m.handleDebugLogKeys(msg)
 	default:
 		return m, nil
 	}
@@ -290,6 +302,11 @@ func (m Model) handleProcessListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.showProjectList = true
 		m.loading = true
 		return m, loadProjects(m.dockerClient)
+
+	case "l": // Show debug log
+		m.currentView = DebugLogView
+		m.loading = true
+		return m, loadCommandLogs(m.dockerClient)
 
 	default:
 		return m, nil
@@ -470,6 +487,47 @@ func (m Model) handleProjectListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.loading = true
 		return m, loadProjects(m.dockerClient)
+
+	default:
+		return m, nil
+	}
+}
+
+func (m Model) handleDebugLogKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q":
+		// Go back to process list
+		m.currentView = ProcessListView
+		return m, loadProcesses(m.dockerClient, m.showAll)
+
+	case "up", "k":
+		if m.debugLogScrollY > 0 {
+			m.debugLogScrollY--
+		}
+		return m, nil
+
+	case "down", "j":
+		maxScroll := len(m.commandLogs) - (m.height - 4)
+		if m.debugLogScrollY < maxScroll && maxScroll > 0 {
+			m.debugLogScrollY++
+		}
+		return m, nil
+
+	case "G":
+		maxScroll := len(m.commandLogs) - (m.height - 4)
+		if maxScroll > 0 {
+			m.debugLogScrollY = maxScroll
+		}
+		return m, nil
+
+	case "g":
+		m.debugLogScrollY = 0
+		return m, nil
+
+	case "r":
+		// Refresh command logs
+		m.loading = true
+		return m, loadCommandLogs(m.dockerClient)
 
 	default:
 		return m, nil

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -476,6 +476,8 @@ func (m Model) handleProjectListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			project := m.projects[m.selectedProject]
 			// Create a new compose client with the selected project
 			m.dockerClient = docker.NewComposeClientWithOptions("", project.Name, "")
+			// Share the command logs with the new client
+			m.dockerClient.SetCommandLogs(&m.sharedCommandLogs)
 			m.projectName = project.Name
 			m.currentView = ProcessListView
 			m.showProjectList = false

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -128,7 +128,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case commandLogsMsg:
 		m.loading = false
 		// Use shared logs directly
-		m.commandLogs = m.sharedCommandLogs
+		if m.sharedCommandLogs != nil {
+			m.commandLogs = *m.sharedCommandLogs
+		} else {
+			m.commandLogs = []docker.CommandLog{}
+		}
 		// Auto-scroll to bottom to show latest commands
 		maxScroll := len(m.commandLogs) - (m.height - 4)
 		if maxScroll > 0 {
@@ -478,7 +482,7 @@ func (m Model) handleProjectListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// Create a new compose client with the selected project
 			m.dockerClient = docker.NewComposeClientWithOptions("", project.Name, "")
 			// Share the command logs with the new client
-			m.dockerClient.SetCommandLogs(&m.sharedCommandLogs)
+			m.dockerClient.SetCommandLogs(m.sharedCommandLogs)
 			m.projectName = project.Name
 			m.currentView = ProcessListView
 			m.showProjectList = false

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -127,7 +127,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case commandLogsMsg:
 		m.loading = false
-		m.commandLogs = msg.logs
+		// Use shared logs directly
+		m.commandLogs = m.sharedCommandLogs
 		// Auto-scroll to bottom to show latest commands
 		maxScroll := len(m.commandLogs) - (m.height - 4)
 		if maxScroll > 0 {


### PR DESCRIPTION
## Summary
- Added a debug log view to show the history of all executed docker compose commands
- Shows command execution details including exit codes, duration, and error messages
- Preserves command history across project switches

## Features
### Debug Log View
- Press 'l' from the process list to access the debug log
- Shows all executed docker compose commands with:
  - Timestamp in HH:MM:SS format
  - Exit code (green [0] for success, red for failures)
  - Execution duration in seconds
  - Full command line
  - Error messages for failed commands (up to 3 lines)
- Supports keyboard navigation (↑/↓, g/G for start/end)
- Command history is preserved when switching between projects

### Implementation Details
- Added `CommandLog` struct to track command execution details
- Modified docker client to log all executed commands
- Shared command logs across all docker client instances using a pointer
- Added manual logging for streaming commands (logs, exec)
- Keeps last 100 commands in memory

## Changes
- `internal/docker/compose.go`: Added command logging functionality
- `internal/ui/model.go`: Added debug log view type and shared command logs
- `internal/ui/view.go`: Added `renderDebugLog` function
- `internal/ui/update.go`: Added debug log keyboard handlers
- `internal/ui/commands.go`: Added logging for streaming commands

## Test plan
- [x] Build the application successfully
- [x] Press 'l' to access debug log view
- [x] Execute various commands and see them logged
- [x] Switch projects and verify history is preserved
- [x] View logs for a container and see the command logged
- [x] Check failed commands show error messages
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)