### PR TITLE
Fix log view not displaying new log lines properly

### DIFF
--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -194,8 +194,8 @@ func pollForLogs() tea.Cmd {
 		lastLogIndex = newIndex
 
 		if len(newLines) > 0 {
-			// Return first new line
-			return logLineMsg{line: newLines[0]}
+			// Return all new lines at once
+			return logLinesMsg{lines: newLines}
 		}
 
 		if done {
@@ -209,7 +209,7 @@ func pollForLogs() tea.Cmd {
 		}
 
 		// No new lines, wait a bit
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		return pollForLogs()()
 	}
 }

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -192,6 +192,7 @@ func pollForLogs() tea.Cmd {
 
 		newLines, newIndex, done := activeLogReader.getNewLines(lastLogIndex)
 		lastLogIndex = newIndex
+		activeLogReader.client.LogDebug(fmt.Sprintf("Got %d new lines.", len(newLines)))
 
 		if len(newLines) > 0 {
 			// Return all new lines at once

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -173,6 +173,10 @@ type logLineMsg struct {
 	line string
 }
 
+type logLinesMsg struct {
+	lines []string
+}
+
 type errorMsg struct {
 	err error
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -63,6 +63,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case logLineMsg:
 		m.logs = append(m.logs, msg.line)
+		// Keep only last 10000 lines to prevent unbounded memory growth
+		if len(m.logs) > 10000 {
+			m.logs = m.logs[len(m.logs)-10000:]
+		}
+		// Auto-scroll to bottom
+		maxScroll := len(m.logs) - (m.height - 4)
+		if maxScroll > 0 {
+			m.logScrollY = maxScroll
+		}
+		// Continue polling for more logs
+		return m, pollForLogs()
+
+	case logLinesMsg:
+		m.logs = append(m.logs, msg.lines...)
+		// Keep only last 10000 lines to prevent unbounded memory growth
+		if len(m.logs) > 10000 {
+			m.logs = m.logs[len(m.logs)-10000:]
+		}
 		// Auto-scroll to bottom
 		maxScroll := len(m.logs) - (m.height - 4)
 		if maxScroll > 0 {


### PR DESCRIPTION
## Summary
- Fixed issue where log lines were collected by `readLogs` but not displayed in the TUI
- Log view now properly shows all new log lines as they arrive

## Problem
The `readLogs` method was collecting log lines into `lr.lines`, but the log view wasn't updating with these new lines. The `pollForLogs` function was only returning one line at a time, causing a backlog of unprocessed lines.

## Solution
- Added `logLinesMsg` message type to handle multiple log lines at once
- Updated `pollForLogs` to return all available new lines in a single message
- Added handler for `logLinesMsg` in the update function
- Reduced polling delay from 100ms to 50ms for more responsive updates
- Added memory limit of 10,000 lines to prevent unbounded growth
- Added debug logging to track how many new lines are retrieved

## Test plan
- [ ] Build the application
- [ ] Run `docker compose up` for a service that produces logs
- [ ] Press Enter on a service to view logs
- [ ] Verify that logs appear in real-time without delays
- [ ] Verify that fast-producing logs are all displayed
- [ ] Check debug log (press 'l') to see "Got X new lines" messages

🤖 Generated with [Claude Code](https://claude.ai/code)