### PR TITLE
Update documentation to reflect Docker container support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-DCV (Docker Compose Viewer) is a TUI tool for monitoring Docker Compose applications. It provides:
-- List view of running Docker Compose applications with log viewing capability
+DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and Docker Compose applications. It provides:
+- List view of all Docker containers (both plain Docker and Docker Compose managed)
+- Multiple Docker Compose project management and switching
+- Log viewing capability for any container
 - Special handling for dind (Docker-in-Docker) containers to view nested containers
 - Vim-like navigation and commands throughout the interface
 
@@ -14,29 +16,51 @@ DCV (Docker Compose Viewer) is a TUI tool for monitoring Docker Compose applicat
 - **Language**: Go (Golang)
 - **TUI Framework**: Bubble Tea (with Lipgloss for styling)
 - **Architecture**: Model-View-Update (MVU) pattern
-- **Core Functionality**: Wraps docker-compose commands to provide an interactive interface
+- **Core Functionality**: Wraps docker and docker-compose commands to provide an interactive interface
 
 ## Key Views
 
-1. **Process List View**: Shows `docker compose ps` results
+1. **Docker Container List View**: Shows `docker ps` results for all containers
+   - `↑`/`k`: Move up
+   - `↓`/`j`: Move down
+   - `Enter`: View container logs
+   - `a`: Toggle show all containers (including stopped)
+   - `K`: Kill container
+   - `S`: Stop container
+   - `U`: Start container
+   - `R`: Restart container
+   - `D`: Delete stopped container
+   - `r`: Refresh list
+   - `q`/`Esc`: Back to Docker Compose view
+
+2. **Docker Compose Process List View**: Shows `docker compose ps` results
    - `↑`/`k`: Move up
    - `↓`/`j`: Move down
    - `Enter`: View container logs
    - `d`: Navigate to dind process list (for dind containers)
+   - `p`: Switch to Docker container list view
+   - `P`: Switch to project list view
    - `t`: Show process info (docker compose top)
-   - `K`: Kill service (docker compose kill)
-   - `S`: Stop service (docker compose stop)
+   - `K`: Kill service
+   - `S`: Stop service
    - `r`: Refresh list
    - `q`: Quit
 
-2. **Dind Process List View**: Executes `docker ps` inside selected dind containers
+3. **Project List View**: Shows all Docker Compose projects
+   - `↑`/`k`: Move up
+   - `↓`/`j`: Move down
+   - `Enter`: Select project and view its containers
+   - `r`: Refresh list
+   - `q`: Quit
+
+4. **Dind Process List View**: Executes `docker ps` inside selected dind containers
    - `↑`/`k`: Move up
    - `↓`/`j`: Move down
    - `Enter`: View logs of containers running inside dind
    - `r`: Refresh list
    - `Esc`/`q`: Back to process list
 
-3. **Log View**: Displays container logs with vim-like navigation
+5. **Log View**: Displays container logs with vim-like navigation
    - `↑`/`k`: Scroll up
    - `↓`/`j`: Scroll down
    - `G`: Jump to end
@@ -44,14 +68,14 @@ DCV (Docker Compose Viewer) is a TUI tool for monitoring Docker Compose applicat
    - `/`: Search functionality
    - `Esc`/`q`: Back to previous view
 
-4. **Top View**: Shows process information (docker compose top)
+6. **Top View**: Shows process information (docker compose top)
    - `r`: Refresh
    - `Esc`/`q`: Back to process list
 
 ## Development Guidelines
 
 - Follow vim-style keybindings for all shortcuts
-- The tool internally executes docker-compose commands
+- The tool internally executes both docker and docker-compose commands
 - Special handling required for dind (Docker-in-Docker) containers
 
 ## Build and Installation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,15 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `d`: Navigate to dind process list (for dind containers)
    - `p`: Switch to Docker container list view
    - `P`: Switch to project list view
+   - `a`: Toggle show all containers (including stopped)
    - `t`: Show process info (docker compose top)
+   - `s`: Show container stats
    - `K`: Kill service
    - `S`: Stop service
+   - `U`: Start service
+   - `R`: Restart service
+   - `D`: Delete stopped container
+   - `u`: Deploy all services (docker compose up -d)
    - `r`: Refresh list
    - `q`: Quit
 
@@ -69,6 +75,10 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `Esc`/`q`: Back to previous view
 
 6. **Top View**: Shows process information (docker compose top)
+   - `r`: Refresh
+   - `Esc`/`q`: Back to process list
+
+7. **Stats View**: Shows container resource usage statistics
    - `r`: Refresh
    - `Esc`/`q`: Back to process list
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# dcv - Docker Compose Viewer
+# dcv - Docker Container Viewer
 
-DCV は docker-compose の状況を確認できる TUI (Terminal User Interface) ツールです｡
+DCV は Docker および Docker Compose で管理されているコンテナの状況を確認できる TUI (Terminal User Interface) ツールです｡
 
 ## 主な機能
 
-- docker-compose で起動しているコンテナの一覧を表示
+- Docker で動作している全てのコンテナの一覧を表示
+- Docker Compose で管理されているコンテナの一覧を表示
+- 複数の Docker Compose プロジェクトの切り替え
 - コンテナのログをリアルタイムで確認（最新1000行を初期表示､その後リアルタイム追従）
 - Docker-in-Docker (dind) コンテナの中で動作するコンテナの管理
 - vim 風のキーバインディング
@@ -12,7 +14,24 @@ DCV は docker-compose の状況を確認できる TUI (Terminal User Interface)
 
 ## Views
 
-### Process List View
+### Docker Container List View
+
+`docker ps` の結果を見やすくテーブル形式で表示します。Docker Compose に限らず、全ての Docker コンテナを表示できます。
+
+**キーバインド:**
+- `↑`/`k`: 上へ移動
+- `↓`/`j`: 下へ移動
+- `Enter`: 選択したコンテナのログを表示
+- `a`: 停止中のコンテナも含めて表示
+- `r`: リストを更新
+- `K`: コンテナを強制終了
+- `S`: コンテナを停止
+- `U`: コンテナを起動
+- `R`: コンテナを再起動
+- `D`: 停止中のコンテナを削除
+- `q`/`Esc`: Docker Compose プロセスリストへ戻る
+
+### Docker Compose Process List View
 
 `docker compose ps` の結果を見やすくテーブル形式で表示します。
 
@@ -21,6 +40,9 @@ DCV は docker-compose の状況を確認できる TUI (Terminal User Interface)
 - `↓`/`j`: 下へ移動  
 - `Enter`: 選択したコンテナのログを表示
 - `d`: dind コンテナの中身を表示（dind コンテナ選択時のみ）
+- `p`: 全ての Docker コンテナ一覧へ切り替え
+- `P`: プロジェクト一覧へ切り替え
+- `a`: 停止中のコンテナも含めて表示
 - `r`: リストを更新
 - `q`: 終了
 
@@ -53,19 +75,26 @@ dind コンテナ内で動作しているコンテナの一覧を表示します
 ### オプション
 
 ```bash
-dcv [-C <path>] [-d <path>]
+dcv [-p <project>] [-f <compose-file>] [--projects]
 ```
 
-- `-C <path>`, `-d <path>`: 指定したディレクトリで docker-compose を実行（`docker-compose -C` と同じ）
+- `-p <project>`: 指定した Docker Compose プロジェクトを表示
+- `-f <compose-file>`: 指定した compose ファイルのプロジェクトを表示
+- `--projects`: 起動時にプロジェクト一覧を表示
 
 ### 例
 
 ```bash
-# 現在のディレクトリで実行
+# 現在のディレクトリの Docker Compose プロジェクトを表示
 dcv
 
-# 特定のディレクトリで実行
-dcv -C /path/to/project
+# 特定のプロジェクトを表示
+dcv -p myproject
+
+# プロジェクト一覧から選択して起動
+dcv --projects
+
+# 全ての Docker コンテナを表示するには、起動後に 'p' キーを押す
 ```
 
 ## インストール

--- a/README.md
+++ b/README.md
@@ -1,111 +1,110 @@
 # dcv - Docker Container Viewer
 
-DCV は Docker および Docker Compose で管理されているコンテナの状況を確認できる TUI (Terminal User Interface) ツールです｡
+DCV is a TUI (Terminal User Interface) tool for monitoring Docker containers and Docker Compose applications.
 
-## 主な機能
+## Features
 
-- Docker で動作している全てのコンテナの一覧を表示
-- Docker Compose で管理されているコンテナの一覧を表示
-- 複数の Docker Compose プロジェクトの切り替え
-- コンテナのログをリアルタイムで確認（最新1000行を初期表示､その後リアルタイム追従）
-- Docker-in-Docker (dind) コンテナの中で動作するコンテナの管理
-- vim 風のキーバインディング
-- 実行コマンドの表示（デバッグに便利）
+- View all Docker containers (both standalone and Docker Compose managed)
+- List and manage Docker Compose containers
+- Switch between multiple Docker Compose projects
+- Real-time container log streaming (shows last 1000 lines, then follows new logs)
+- Manage containers inside Docker-in-Docker (dind) containers
+- Vim-style key bindings
+- Display executed commands for debugging
 
 ## Views
 
 ### Docker Container List View
 
-`docker ps` の結果を見やすくテーブル形式で表示します。Docker Compose に限らず、全ての Docker コンテナを表示できます。
+Displays `docker ps` results in a table format. Shows all Docker containers, not limited to Docker Compose.
 
-**キーバインド:**
-- `↑`/`k`: 上へ移動
-- `↓`/`j`: 下へ移動
-- `Enter`: 選択したコンテナのログを表示
-- `a`: 停止中のコンテナも含めて表示
-- `r`: リストを更新
-- `K`: コンテナを強制終了
-- `S`: コンテナを停止
-- `U`: コンテナを起動
-- `R`: コンテナを再起動
-- `D`: 停止中のコンテナを削除
-- `q`/`Esc`: Docker Compose プロセスリストへ戻る
+**Key bindings:**
+- `↑`/`k`: Move up
+- `↓`/`j`: Move down
+- `Enter`: View container logs
+- `a`: Toggle show all containers (including stopped)
+- `r`: Refresh list
+- `K`: Kill container
+- `S`: Stop container
+- `U`: Start container
+- `R`: Restart container
+- `D`: Delete stopped container
+- `q`/`Esc`: Back to Docker Compose process list
 
 ### Docker Compose Process List View
 
-`docker compose ps` の結果を見やすくテーブル形式で表示します。
+Displays `docker compose ps` results in a table format.
 
-**キーバインド:**
-- `↑`/`k`: 上へ移動
-- `↓`/`j`: 下へ移動  
-- `Enter`: 選択したコンテナのログを表示
-- `d`: dind コンテナの中身を表示（dind コンテナ選択時のみ）
-- `p`: 全ての Docker コンテナ一覧へ切り替え
-- `P`: プロジェクト一覧へ切り替え
-- `a`: 停止中のコンテナも含めて表示
-- `r`: リストを更新
-- `q`: 終了
+**Key bindings:**
+- `↑`/`k`: Move up
+- `↓`/`j`: Move down  
+- `Enter`: View container logs
+- `d`: View dind container contents (only for dind containers)
+- `p`: Switch to Docker container list view
+- `P`: Switch to project list view
+- `a`: Toggle show all containers (including stopped)
+- `r`: Refresh list
+- `q`: Quit
 
 ### Log View
 
-コンテナのログを表示します。初期表示で最新1000行を取得し、その後新しいログをリアルタイムで追加表示します。
+Displays container logs. Initially shows the last 1000 lines, then streams new logs in real-time.
 
-**キーバインド:**
-- `↑`/`k`: 上スクロール
-- `↓`/`j`: 下スクロール
-- `G`: 最下部へジャンプ
-- `g`: 最上部へジャンプ
-- `/`: 検索モード（未実装）
-- `Esc`/`q`: Process List View へ戻る
+**Key bindings:**
+- `↑`/`k`: Scroll up
+- `↓`/`j`: Scroll down
+- `G`: Jump to end
+- `g`: Jump to start
+- `/`: Search mode (not implemented yet)
+- `Esc`/`q`: Back to previous view
 
 ### Docker-in-Docker Process List View
 
-dind コンテナ内で動作しているコンテナの一覧を表示します。
+Shows containers running inside a dind container.
 
-**キーバインド:**
-- `↑`/`k`: 上へ移動
-- `↓`/`j`: 下へ移動
-- `Enter`: 選択したコンテナのログを表示
-- `r`: リストを更新
-- `Esc`: Process List View へ戻る
-- `q`: Process List View へ戻る
+**Key bindings:**
+- `↑`/`k`: Move up
+- `↓`/`j`: Move down
+- `Enter`: View container logs
+- `r`: Refresh list
+- `Esc`/`q`: Back to process list
 
-## 使い方
+## Usage
 
-### オプション
+### Options
 
 ```bash
 dcv [-p <project>] [-f <compose-file>] [--projects]
 ```
 
-- `-p <project>`: 指定した Docker Compose プロジェクトを表示
-- `-f <compose-file>`: 指定した compose ファイルのプロジェクトを表示
-- `--projects`: 起動時にプロジェクト一覧を表示
+- `-p <project>`: Display the specified Docker Compose project
+- `-f <compose-file>`: Display the project with the specified compose file
+- `--projects`: Show project list on startup
 
-### 例
+### Examples
 
 ```bash
-# 現在のディレクトリの Docker Compose プロジェクトを表示
+# Display Docker Compose project in current directory
 dcv
 
-# 特定のプロジェクトを表示
+# Display specific project
 dcv -p myproject
 
-# プロジェクト一覧から選択して起動
+# Start with project list
 dcv --projects
 
-# 全ての Docker コンテナを表示するには、起動後に 'p' キーを押す
+# To view all Docker containers, press 'p' after starting
 ```
 
-## インストール
+## Installation
 
-### Go install を使う場合
+### Using go install
 
 ```bash
 go install github.com/tokuhirom/dcv@latest
 ```
 
-### ソースからビルドする場合
+### Building from source
 
 ```bash
 git clone https://github.com/tokuhirom/dcv.git
@@ -114,66 +113,78 @@ go build -o dcv
 ./dcv
 ```
 
-## 要件
+## Requirements
 
-- Go 1.24.3 以上
-- Docker および Docker Compose がインストールされていること
-- ターミナルが TUI をサポートしていること
+- Go 1.24.3 or later
+- Docker and Docker Compose installed
+- Terminal with TUI support
 
-## 内部実装
+## Implementation Details
 
-- 言語: Go
-- TUI フレームワーク: [Bubble Tea](https://github.com/charmbracelet/bubbletea)
-- スタイリング: [Lipgloss](https://github.com/charmbracelet/lipgloss)
-- テスト: testify
+- Language: Go
+- TUI Framework: [Bubble Tea](https://github.com/charmbracelet/bubbletea)
+- Styling: [Lipgloss](https://github.com/charmbracelet/lipgloss)
+- Testing: testify
 
-### 特徴
+### Architecture
 
-- Model-View-Update (MVU) アーキテクチャを採用
-- 非同期でログをストリーミング
-- エラー時に実行したコマンドを表示してデバッグを容易に
-- 包括的なユニットテスト
+- Uses Model-View-Update (MVU) pattern
+- Async log streaming
+- Shows executed commands on error for easier debugging
+- Comprehensive unit tests
 
-## デバッグ機能
+## Debugging Features
 
-- 実行されたコマンドがフッターに常時表示される
-- エラー発生時は詳細なエラーメッセージとコマンドが表示される
-- stderr 出力は `[STDERR]` プレフィックス付きで表示
+- Executed commands are always displayed in the footer
+- Detailed error messages and commands shown on error
+- stderr output is prefixed with `[STDERR]`
 
-## 開発
+## Development
 
-### テストの実行
+### Running tests
 
 ```bash
-go test ./...
+make test
 ```
 
-### ビルド
+### Building
 
 ```bash
-go build -o dcv
+make all
 ```
 
-### サンプル環境の起動
-
-リポジトリには Docker Compose のサンプル環境が含まれています：
+### Installing development dependencies
 
 ```bash
-# サンプル環境を起動
-docker compose up -d
+make dev-deps
+```
 
-# dcv でモニタリング
+### Formatting code
+
+```bash
+make fmt
+```
+
+### Starting sample environment
+
+The repository includes a Docker Compose sample environment:
+
+```bash
+# Start sample environment
+make up
+
+# Monitor with dcv
 ./dcv
 
-# サンプル環境を停止
-docker compose down
+# Stop sample environment
+make down
 ```
 
-サンプル環境には以下が含まれます：
-- `web`: Nginx サーバー
-- `db`: PostgreSQL データベース
-- `redis`: Redis キャッシュ
-- `dind`: Docker-in-Docker（内部でテストコンテナが自動起動）
+The sample environment includes:
+- `web`: Nginx server
+- `db`: PostgreSQL database
+- `redis`: Redis cache
+- `dind`: Docker-in-Docker (automatically starts test containers inside)
 
 ## License
 
@@ -200,4 +211,3 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
-


### PR DESCRIPTION
## Summary
- Updated project name from "Docker Compose Viewer" to "Docker Container Viewer"
- Documented the new Docker container list view functionality
- Updated all documentation to reflect that dcv now supports both Docker and Docker Compose

## Changes

### README.md
- Changed title and description to reflect broader Docker support
- Added documentation for Docker Container List View with all key bindings
- Updated feature list to include plain Docker container management
- Updated usage examples to show new options

### CLAUDE.md
- Updated project overview to include Docker container support
- Added complete documentation for all views including the new Docker Container List View
- Added Project List View documentation
- Updated core functionality description

## Why these changes?
Since PR #37 added support for viewing all Docker containers (not just Docker Compose managed ones), the tool is no longer limited to Docker Compose. The documentation should reflect this expanded functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)