### PR TITLE
feat: add Docker image list view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and Docker Compose applications. It provides:
 - List view of all Docker containers (both plain Docker and Docker Compose managed)
+- List and manage Docker images
 - Multiple Docker Compose project management and switching
 - Log viewing capability for any container
 - Special handling for dind (Docker-in-Docker) containers to view nested containers
@@ -39,6 +40,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `Enter`: View container logs
    - `d`: Navigate to dind process list (for dind containers)
    - `p`: Switch to Docker container list view
+   - `i`: Switch to Docker image list view
    - `P`: Switch to project list view
    - `a`: Toggle show all containers (including stopped)
    - `t`: Show process info (docker compose top)
@@ -52,21 +54,30 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `r`: Refresh list
    - `q`: Quit
 
-3. **Project List View**: Shows all Docker Compose projects
+3. **Image List View**: Shows Docker images with repository, tag, ID, creation time, and size
+   - `↑`/`k`: Move up
+   - `↓`/`j`: Move down
+   - `a`: Toggle show all images (including intermediate layers)
+   - `r`: Refresh list
+   - `D`: Remove selected image
+   - `F`: Force remove selected image (even if used by containers)
+   - `Esc`/`q`: Back to Docker Compose process list
+
+4. **Project List View**: Shows all Docker Compose projects
    - `↑`/`k`: Move up
    - `↓`/`j`: Move down
    - `Enter`: Select project and view its containers
    - `r`: Refresh list
    - `q`: Quit
 
-4. **Dind Process List View**: Executes `docker ps` inside selected dind containers
+5. **Dind Process List View**: Executes `docker ps` inside selected dind containers
    - `↑`/`k`: Move up
    - `↓`/`j`: Move down
    - `Enter`: View logs of containers running inside dind
    - `r`: Refresh list
    - `Esc`/`q`: Back to process list
 
-5. **Log View**: Displays container logs with vim-like navigation
+6. **Log View**: Displays container logs with vim-like navigation
    - `↑`/`k`: Scroll up
    - `↓`/`j`: Scroll down
    - `G`: Jump to end
@@ -74,11 +85,11 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `/`: Search functionality
    - `Esc`/`q`: Back to previous view
 
-6. **Top View**: Shows process information (docker compose top)
+7. **Top View**: Shows process information (docker compose top)
    - `r`: Refresh
    - `Esc`/`q`: Back to process list
 
-7. **Stats View**: Shows container resource usage statistics
+8. **Stats View**: Shows container resource usage statistics
    - `r`: Refresh
    - `Esc`/`q`: Back to process list
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ DCV is a TUI (Terminal User Interface) tool for monitoring Docker containers and
 ## Features
 
 - View all Docker containers (both standalone and Docker Compose managed)
+- List and manage Docker images
 - List and manage Docker Compose containers
 - Switch between multiple Docker Compose projects
 - Real-time container log streaming (shows last 1000 lines, then follows new logs)
@@ -68,6 +69,19 @@ Shows containers running inside a dind container.
 - `Enter`: View container logs
 - `r`: Refresh list
 - `Esc`/`q`: Back to process list
+
+### Image List View
+
+Displays Docker images with repository, tag, ID, creation time, and size information.
+
+**Key bindings:**
+- `↑`/`k`: Move up
+- `↓`/`j`: Move down
+- `a`: Toggle show all images (including intermediate layers)
+- `r`: Refresh list
+- `D`: Remove selected image
+- `F`: Force remove selected image (even if used by containers)
+- `Esc`/`q`: Back to Docker Compose process list
 
 ## Usage
 

--- a/internal/models/docker_image.go
+++ b/internal/models/docker_image.go
@@ -1,0 +1,27 @@
+package models
+
+// DockerImage represents an image from `docker images --format json`
+type DockerImage struct {
+	Containers   string `json:"Containers"`
+	CreatedAt    string `json:"CreatedAt"`
+	CreatedSince string `json:"CreatedSince"`
+	Digest       string `json:"Digest"`
+	ID           string `json:"ID"`
+	Repository   string `json:"Repository"`
+	SharedSize   string `json:"SharedSize"`
+	Size         string `json:"Size"`
+	Tag          string `json:"Tag"`
+	UniqueSize   string `json:"UniqueSize"`
+	VirtualSize  string `json:"VirtualSize"`
+}
+
+// GetRepoTag returns the repository:tag string
+func (i DockerImage) GetRepoTag() string {
+	if i.Repository == "<none>" {
+		return i.ID
+	}
+	if i.Tag == "<none>" {
+		return i.Repository
+	}
+	return i.Repository + ":" + i.Tag
+}

--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -480,3 +480,58 @@ func (m *Model) GetStyledHelpText() string {
 
 	return style.Render(helpText)
 }
+
+// Image list handlers
+func (m *Model) SelectUpImage(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectedDockerImage > 0 {
+		m.selectedDockerImage--
+	}
+	return m, nil
+}
+
+func (m *Model) SelectDownImage(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectedDockerImage < len(m.dockerImages)-1 {
+		m.selectedDockerImage++
+	}
+	return m, nil
+}
+
+func (m *Model) ShowImageList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.currentView = ImageListView
+	m.loading = true
+	return m, loadDockerImages(m.dockerClient, m.showAll)
+}
+
+func (m *Model) RefreshImageList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.loading = true
+	return m, loadDockerImages(m.dockerClient, m.showAll)
+}
+
+func (m *Model) ToggleAllImages(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.showAll = !m.showAll
+	m.loading = true
+	return m, loadDockerImages(m.dockerClient, m.showAll)
+}
+
+func (m *Model) DeleteImage(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectedDockerImage < len(m.dockerImages) {
+		image := m.dockerImages[m.selectedDockerImage]
+		m.loading = true
+		return m, removeImage(m.dockerClient, image.GetRepoTag(), false)
+	}
+	return m, nil
+}
+
+func (m *Model) ForceDeleteImage(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectedDockerImage < len(m.dockerImages) {
+		image := m.dockerImages[m.selectedDockerImage]
+		m.loading = true
+		return m, removeImage(m.dockerClient, image.GetRepoTag(), true)
+	}
+	return m, nil
+}
+
+func (m *Model) BackFromImageList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.currentView = ComposeProcessListView
+	return m, loadProcesses(m.dockerClient, m.projectName, m.showAll)
+}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -12,6 +12,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"enter"}, "view logs", m.ShowComposeLog},
 		{[]string{"d"}, "dind containers", m.ShowDindProcessList},
 		{[]string{"p"}, "docker ps", m.ShowDockerContainerList},
+		{[]string{"i"}, "docker images", m.ShowImageList},
 		{[]string{"r"}, "refresh", m.RefreshProcessList},
 		{[]string{"a"}, "toggle all", m.ToggleAllContainers},
 		{[]string{"s"}, "stats", m.ShowStatsView},
@@ -83,6 +84,18 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"esc", "q"}, "back", m.BackFromDockerList},
 	}
 	m.dockerListViewKeymap = m.createKeymap(m.dockerListViewHandlers)
+
+	// Image List View
+	m.imageListViewHandlers = []KeyConfig{
+		{[]string{"up", "k"}, "move up", m.SelectUpImage},
+		{[]string{"down", "j"}, "move down", m.SelectDownImage},
+		{[]string{"r"}, "refresh", m.RefreshImageList},
+		{[]string{"a"}, "toggle all", m.ToggleAllImages},
+		{[]string{"D"}, "remove", m.DeleteImage},
+		{[]string{"F"}, "force remove", m.ForceDeleteImage},
+		{[]string{"esc", "q"}, "back", m.BackFromImageList},
+	}
+	m.imageListViewKeymap = m.createKeymap(m.imageListViewHandlers)
 
 	slog.Info("Initialized all view keymaps")
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -35,6 +35,7 @@ const (
 	StatsView
 	ProjectListView
 	DockerContainerListView
+	ImageListView
 )
 
 // Model represents the application state
@@ -63,6 +64,10 @@ type Model struct {
 	// Docker containers state (plain docker ps)
 	dockerContainers        []models.DockerContainer
 	selectedDockerContainer int
+
+	// Docker images state
+	dockerImages        []models.DockerImage
+	selectedDockerImage int
 
 	// Log view state
 	logs          []string
@@ -110,6 +115,8 @@ type Model struct {
 	projectListViewHandlers []KeyConfig
 	dockerListViewKeymap    map[string]KeyHandler
 	dockerListViewHandlers  []KeyConfig
+	imageListViewKeymap     map[string]KeyHandler
+	imageListViewHandlers   []KeyConfig
 }
 
 // NewModel creates a new model with initial state
@@ -202,6 +209,11 @@ type projectsLoadedMsg struct {
 type dockerContainersLoadedMsg struct {
 	containers []models.DockerContainer
 	err        error
+}
+
+type dockerImagesLoadedMsg struct {
+	images []models.DockerImage
+	err    error
 }
 
 // Commands
@@ -359,6 +371,27 @@ func loadDockerContainers(client *docker.Client, showAll bool) tea.Cmd {
 		return dockerContainersLoadedMsg{
 			containers: containers,
 			err:        err,
+		}
+	}
+}
+
+func loadDockerImages(client *docker.Client, showAll bool) tea.Cmd {
+	return func() tea.Msg {
+		images, err := client.ListImages(showAll)
+		return dockerImagesLoadedMsg{
+			images: images,
+			err:    err,
+		}
+	}
+}
+
+func removeImage(client *docker.Client, imageID string, force bool) tea.Cmd {
+	return func() tea.Msg {
+		err := client.RemoveImage(imageID, force)
+		return serviceActionCompleteMsg{
+			action:  "remove image",
+			service: imageID,
+			err:     err,
 		}
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -68,6 +68,8 @@ func (m *Model) View() string {
 		return m.renderProjectList()
 	case DockerContainerListView:
 		return m.renderDockerList()
+	case ImageListView:
+		return m.renderImageList()
 	default:
 		return "Unknown view"
 	}

--- a/internal/ui/view_images.go
+++ b/internal/ui/view_images.go
@@ -1,0 +1,123 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+)
+
+func (m *Model) renderImageList() string {
+	var s strings.Builder
+
+	// Title
+	title := "Docker Images"
+	if m.showAll {
+		title += " (All)"
+	}
+	s.WriteString(lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("86")).
+		Render(title) + "\n\n")
+
+	// Loading or error state
+	if m.loading {
+		s.WriteString("Loading images...\n")
+		return s.String()
+	}
+
+	if m.err != nil {
+		s.WriteString(fmt.Sprintf("Error: %v\n", m.err))
+		return s.String()
+	}
+
+	// No images
+	if len(m.dockerImages) == 0 {
+		s.WriteString("No images found.\n")
+		s.WriteString("Press 'r' to refresh.\n")
+		return s.String()
+	}
+
+	// Create table
+	t := table.New()
+	t.Headers("REPOSITORY", "TAG", "IMAGE ID", "CREATED", "SIZE")
+
+	// Configure column widths based on terminal width
+	// Approximate widths: REPOSITORY(30), TAG(15), IMAGE ID(12), CREATED(15), SIZE(10)
+	availableWidth := m.width - 10 // margin
+	repoWidth := 30
+	if availableWidth < 100 {
+		repoWidth = 20
+	}
+	t.Width(availableWidth).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == 0 {
+				return lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("99"))
+			}
+			return lipgloss.NewStyle()
+		})
+
+	// Styles
+	selectedStyle := lipgloss.NewStyle().Background(lipgloss.Color("238"))
+	repoStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("86"))
+	tagStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("229"))
+	idStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	createdStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	sizeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("213"))
+
+	// Add rows
+	for i, image := range m.dockerImages {
+		var rowRepoStyle, rowTagStyle, rowIdStyle, rowCreatedStyle, rowSizeStyle lipgloss.Style
+
+		if i == m.selectedDockerImage {
+			rowRepoStyle = selectedStyle.Inherit(repoStyle)
+			rowTagStyle = selectedStyle.Inherit(tagStyle)
+			rowIdStyle = selectedStyle.Inherit(idStyle)
+			rowCreatedStyle = selectedStyle.Inherit(createdStyle)
+			rowSizeStyle = selectedStyle.Inherit(sizeStyle)
+		} else {
+			rowRepoStyle = repoStyle
+			rowTagStyle = tagStyle
+			rowIdStyle = idStyle
+			rowCreatedStyle = createdStyle
+			rowSizeStyle = sizeStyle
+		}
+
+		// Handle <none> repository
+		repo := image.Repository
+		if repo == "<none>" {
+			repo = "<none>"
+		}
+		if len(repo) > repoWidth {
+			repo = repo[:repoWidth-3] + "..."
+		}
+		repo = rowRepoStyle.Render(repo)
+
+		tag := rowTagStyle.Render(image.Tag)
+		
+		// Show first 12 chars of ID
+		id := image.ID
+		if len(id) > 12 {
+			id = id[:12]
+		}
+		id = rowIdStyle.Render(id)
+
+		created := rowCreatedStyle.Render(image.CreatedSince)
+		size := rowSizeStyle.Render(image.Size)
+
+		t.Row(repo, tag, id, created, size)
+	}
+
+	s.WriteString(t.Render() + "\n\n")
+
+	// Help text
+	helpText := m.GetStyledHelpText()
+	if helpText != "" {
+		s.WriteString(helpText)
+	}
+
+	return s.String()
+}


### PR DESCRIPTION
## Summary
- Added comprehensive Docker image list view to dcv
- Accessible via 'i' key from the Docker Compose process list
- Provides full image management capabilities including viewing and removal

## Features
- **Image List Display**: Shows repository, tag, ID, creation time, and size
- **Toggle All Images**: Press 'a' to show/hide intermediate layers
- **Image Removal**: 
  - 'D' for normal removal
  - 'F' for force removal (even if used by containers)
- **Vim-style Navigation**: Consistent with rest of the application

## Implementation Details
- Added `DockerImage` model to parse JSON from `docker images --format json`
- Implemented `ListImages` and `RemoveImage` methods in Docker client
- Created dedicated `view_images.go` for rendering the image list
- Integrated with existing MVU architecture and key handling system
- Updated both README.md and CLAUDE.md documentation

## Test Plan
- [ ] Navigate to image list view with 'i' key
- [ ] Verify image list displays correctly
- [ ] Test toggling all images with 'a'
- [ ] Test image removal (both normal and force)
- [ ] Verify navigation back to process list with 'q' or 'Esc'
- [ ] Test refresh functionality with 'r'

🤖 Generated with [Claude Code](https://claude.ai/code)