### PR TITLE
feat: add Docker network list view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and Docker Compose applications. It provides:
 - List view of all Docker containers (both plain Docker and Docker Compose managed)
 - List and manage Docker images
+- List and manage Docker networks
 - Multiple Docker Compose project management and switching
 - Log viewing capability for any container
 - Special handling for dind (Docker-in-Docker) containers to view nested containers
@@ -41,6 +42,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `d`: Navigate to dind process list (for dind containers)
    - `p`: Switch to Docker container list view
    - `i`: Switch to Docker image list view
+   - `n`: Switch to Docker network list view
    - `P`: Switch to project list view
    - `a`: Toggle show all containers (including stopped)
    - `t`: Show process info (docker compose top)
@@ -93,6 +95,13 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `r`: Refresh
    - `Esc`/`q`: Back to process list
 
+9. **Network List View**: Shows Docker networks with ID, name, driver, scope, and container count
+   - `↑`/`k`: Move up
+   - `↓`/`j`: Move down
+   - `r`: Refresh list
+   - `D`: Remove selected network (except default networks)
+   - `Esc`/`q`: Back to Docker Compose process list
+
 ## Development Guidelines
 
 - Follow vim-style keybindings for all shortcuts
@@ -135,7 +144,7 @@ go build -o dcv
 - **View compose file** - Display the active docker-compose.yml
 
 ### Network & Volume Management
-- **Network list/inspect** - View Docker networks
+- **Network inspect** - View detailed network information
 - **Volume list/inspect** - Manage Docker volumes
 - **Network connections** - Show container network relationships
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ DCV is a TUI (Terminal User Interface) tool for monitoring Docker containers and
 
 - View all Docker containers (both standalone and Docker Compose managed)
 - List and manage Docker images
+- List and manage Docker networks
 - List and manage Docker Compose containers
 - Switch between multiple Docker Compose projects
 - Real-time container log streaming (shows last 1000 lines, then follows new logs)
@@ -42,6 +43,8 @@ Displays `docker compose ps` results in a table format.
 - `Enter`: View container logs
 - `d`: View dind container contents (only for dind containers)
 - `p`: Switch to Docker container list view
+- `i`: Switch to Docker image list view
+- `n`: Switch to Docker network list view
 - `P`: Switch to project list view
 - `a`: Toggle show all containers (including stopped)
 - `r`: Refresh list
@@ -81,6 +84,17 @@ Displays Docker images with repository, tag, ID, creation time, and size informa
 - `r`: Refresh list
 - `D`: Remove selected image
 - `F`: Force remove selected image (even if used by containers)
+- `Esc`/`q`: Back to Docker Compose process list
+
+### Network List View
+
+Displays Docker networks with ID, name, driver, scope, and container count.
+
+**Key bindings:**
+- `↑`/`k`: Move up
+- `↓`/`j`: Move down
+- `r`: Refresh list
+- `D`: Remove selected network (except default networks)
 - `Esc`/`q`: Back to Docker Compose process list
 
 ## Usage

--- a/internal/models/docker_network.go
+++ b/internal/models/docker_network.go
@@ -1,0 +1,48 @@
+package models
+
+// DockerNetwork represents a Docker network
+type DockerNetwork struct {
+	Name      string `json:"Name"`
+	ID        string `json:"ID"`
+	Created   string `json:"Created"`
+	Scope     string `json:"Scope"`
+	Driver    string `json:"Driver"`
+	EnableIPv6 bool   `json:"EnableIPv6"`
+	IPAM      struct {
+		Driver string `json:"Driver"`
+		Options map[string]string `json:"Options"`
+		Config []struct {
+			Subnet string `json:"Subnet"`
+			Gateway string `json:"Gateway"`
+		} `json:"Config"`
+	} `json:"IPAM"`
+	Internal   bool `json:"Internal"`
+	Attachable bool `json:"Attachable"`
+	Ingress    bool `json:"Ingress"`
+	ConfigFrom struct {
+		Network string `json:"Network"`
+	} `json:"ConfigFrom"`
+	ConfigOnly bool `json:"ConfigOnly"`
+	Containers map[string]struct {
+		Name        string `json:"Name"`
+		EndpointID  string `json:"EndpointID"`
+		MacAddress  string `json:"MacAddress"`
+		IPv4Address string `json:"IPv4Address"`
+		IPv6Address string `json:"IPv6Address"`
+	} `json:"Containers"`
+	Options map[string]string `json:"Options"`
+	Labels  map[string]string `json:"Labels"`
+}
+
+// GetSubnet returns the first subnet if available
+func (n DockerNetwork) GetSubnet() string {
+	if len(n.IPAM.Config) > 0 {
+		return n.IPAM.Config[0].Subnet
+	}
+	return ""
+}
+
+// GetContainerCount returns the number of containers attached to the network
+func (n DockerNetwork) GetContainerCount() int {
+	return len(n.Containers)
+}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -13,6 +13,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"d"}, "dind containers", m.ShowDindProcessList},
 		{[]string{"p"}, "docker ps", m.ShowDockerContainerList},
 		{[]string{"i"}, "docker images", m.ShowImageList},
+		{[]string{"n"}, "docker networks", m.ShowNetworkList},
 		{[]string{"r"}, "refresh", m.RefreshProcessList},
 		{[]string{"a"}, "toggle all", m.ToggleAllContainers},
 		{[]string{"s"}, "stats", m.ShowStatsView},
@@ -96,6 +97,16 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"esc", "q"}, "back", m.BackFromImageList},
 	}
 	m.imageListViewKeymap = m.createKeymap(m.imageListViewHandlers)
+
+	// Network List View
+	m.networkListViewHandlers = []KeyConfig{
+		{[]string{"up", "k"}, "move up", m.SelectUpNetwork},
+		{[]string{"down", "j"}, "move down", m.SelectDownNetwork},
+		{[]string{"r"}, "refresh", m.RefreshNetworkList},
+		{[]string{"D"}, "remove", m.DeleteNetwork},
+		{[]string{"esc", "q"}, "back", m.BackFromNetworkList},
+	}
+	m.networkListViewKeymap = m.createKeymap(m.networkListViewHandlers)
 
 	slog.Info("Initialized all view keymaps")
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -36,6 +36,7 @@ const (
 	ProjectListView
 	DockerContainerListView
 	ImageListView
+	NetworkListView
 )
 
 // Model represents the application state
@@ -68,6 +69,10 @@ type Model struct {
 	// Docker images state
 	dockerImages        []models.DockerImage
 	selectedDockerImage int
+
+	// Docker networks state
+	dockerNetworks        []models.DockerNetwork
+	selectedDockerNetwork int
 
 	// Log view state
 	logs          []string
@@ -117,6 +122,8 @@ type Model struct {
 	dockerListViewHandlers  []KeyConfig
 	imageListViewKeymap     map[string]KeyHandler
 	imageListViewHandlers   []KeyConfig
+	networkListViewKeymap   map[string]KeyHandler
+	networkListViewHandlers []KeyConfig
 }
 
 // NewModel creates a new model with initial state
@@ -214,6 +221,11 @@ type dockerContainersLoadedMsg struct {
 type dockerImagesLoadedMsg struct {
 	images []models.DockerImage
 	err    error
+}
+
+type dockerNetworksLoadedMsg struct {
+	networks []models.DockerNetwork
+	err      error
 }
 
 // Commands
@@ -391,6 +403,27 @@ func removeImage(client *docker.Client, imageID string, force bool) tea.Cmd {
 		return serviceActionCompleteMsg{
 			action:  "remove image",
 			service: imageID,
+			err:     err,
+		}
+	}
+}
+
+func loadDockerNetworks(client *docker.Client) tea.Cmd {
+	return func() tea.Msg {
+		networks, err := client.ListNetworks()
+		return dockerNetworksLoadedMsg{
+			networks: networks,
+			err:      err,
+		}
+	}
+}
+
+func removeNetwork(client *docker.Client, networkID string) tea.Cmd {
+	return func() tea.Msg {
+		err := client.RemoveNetwork(networkID)
+		return serviceActionCompleteMsg{
+			action:  "remove network",
+			service: networkID,
 			err:     err,
 		}
 	}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -122,6 +122,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, loadDockerImages(m.dockerClient, m.showAll)
 		case DockerContainerListView:
 			return m, loadDockerContainers(m.dockerClient, m.showAll)
+		case NetworkListView:
+			return m, loadDockerNetworks(m.dockerClient)
 		default:
 			return m, loadProcesses(m.dockerClient, m.projectName, m.showAll)
 		}
@@ -183,6 +185,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case dockerNetworksLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.dockerNetworks = msg.networks
+		m.err = nil
+		if len(m.dockerNetworks) > 0 && m.selectedDockerNetwork >= len(m.dockerNetworks) {
+			m.selectedDockerNetwork = 0
+		}
+		return m, nil
+
 	default:
 		return m, nil
 	}
@@ -230,6 +245,8 @@ func (m *Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleDockerListKeys(msg)
 	case ImageListView:
 		return m.handleImageListKeys(msg)
+	case NetworkListView:
+		return m.handleNetworkListKeys(msg)
 	default:
 		return m, nil
 	}
@@ -322,6 +339,14 @@ func (m *Model) handleDockerListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) handleImageListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	handler, ok := m.imageListViewKeymap[msg.String()]
+	if ok {
+		return handler(msg)
+	}
+	return m, nil
+}
+
+func (m *Model) handleNetworkListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	handler, ok := m.networkListViewKeymap[msg.String()]
 	if ok {
 		return handler(msg)
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -70,6 +70,8 @@ func (m *Model) View() string {
 		return m.renderDockerList()
 	case ImageListView:
 		return m.renderImageList()
+	case NetworkListView:
+		return m.renderNetworkList()
 	default:
 		return "Unknown view"
 	}

--- a/internal/ui/view_networks.go
+++ b/internal/ui/view_networks.go
@@ -1,0 +1,101 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderNetworkList renders the network list view
+func (m *Model) renderNetworkList() string {
+	var content strings.Builder
+
+	// Title
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	content.WriteString(titleStyle.Render("Docker Networks"))
+	content.WriteString("\n\n")
+
+	if m.loading {
+		return content.String() + "Loading networks..."
+	}
+
+	if m.err != nil {
+		errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+		return content.String() + errorStyle.Render(fmt.Sprintf("Error: %v", m.err))
+	}
+
+	if len(m.dockerNetworks) == 0 {
+		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		return content.String() + dimStyle.Render("No networks found")
+	}
+
+	// Table headers
+	headerStyle := lipgloss.NewStyle().Bold(true).Underline(true).Foreground(lipgloss.Color("86"))
+	headers := []string{"NETWORK ID", "NAME", "DRIVER", "SCOPE", "CONTAINERS"}
+	colWidths := []int{12, 30, 15, 10, 10}
+
+	// Render headers
+	for i, header := range headers {
+		content.WriteString(headerStyle.Render(padRight(header, colWidths[i])))
+		if i < len(headers)-1 {
+			content.WriteString(" ")
+		}
+	}
+	content.WriteString("\n")
+
+	// Render networks
+	normalStyle := lipgloss.NewStyle()
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("220")).Background(lipgloss.Color("235"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+
+	for i, network := range m.dockerNetworks {
+		style := normalStyle
+		if i == m.selectedDockerNetwork {
+			style = selectedStyle
+		}
+
+		// Format row data
+		row := []string{
+			truncate(network.ID, 12),
+			truncate(network.Name, 30),
+			truncate(network.Driver, 15),
+			truncate(network.Scope, 10),
+			fmt.Sprintf("%d", network.GetContainerCount()),
+		}
+
+		// Render row
+		for j, col := range row {
+			if j == 0 && i != m.selectedDockerNetwork {
+				// Dim the ID for non-selected rows
+				content.WriteString(dimStyle.Render(padRight(col, colWidths[j])))
+			} else {
+				content.WriteString(style.Render(padRight(col, colWidths[j])))
+			}
+			if j < len(row)-1 {
+				content.WriteString(" ")
+			}
+		}
+		content.WriteString("\n")
+	}
+
+	return content.String()
+}
+
+// Helper functions
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func padRight(s string, length int) string {
+	if len(s) >= length {
+		return s[:length]
+	}
+	return s + strings.Repeat(" ", length-len(s))
+}


### PR DESCRIPTION
## Summary
- Added comprehensive Docker network list view to dcv
- Accessible via 'n' key from the Docker Compose process list
- Provides network viewing and management capabilities

## Features
- **Network List Display**: Shows ID, name, driver, scope, and container count
- **Network Removal**: Press 'D' to remove networks (protected against removing default networks)
- **Vim-style Navigation**: Consistent with rest of the application

## Implementation Details
- Added `DockerNetwork` model to parse JSON from `docker network ls --format json`
- Implemented `ListNetworks` and `RemoveNetwork` methods in Docker client
- Created dedicated `view_networks.go` for rendering the network list
- Integrated with existing MVU architecture and key handling system
- Updated both README.md and CLAUDE.md documentation
- Removed network list from potential missing features in CLAUDE.md

## Test Plan
- [ ] Navigate to network list view with 'n' key
- [ ] Verify network list displays correctly with all columns
- [ ] Test navigation with up/down arrow keys and j/k
- [ ] Test network removal with 'D' key
- [ ] Verify default networks (bridge, host, none) cannot be removed
- [ ] Test refresh functionality with 'r'
- [ ] Verify navigation back to process list with 'q' or 'Esc'

🤖 Generated with [Claude Code](https://claude.ai/code)