### PR TITLE
feat: add container file browser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
 - List view of all Docker containers (both plain Docker and Docker Compose managed)
 - List and manage Docker images
 - List and manage Docker networks
+- Browse files inside containers
 - Multiple Docker Compose project management and switching
 - Log viewing capability for any container
 - Special handling for dind (Docker-in-Docker) containers to view nested containers
@@ -26,6 +27,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `↑`/`k`: Move up
    - `↓`/`j`: Move down
    - `Enter`: View container logs
+   - `f`: Browse container files
    - `a`: Toggle show all containers (including stopped)
    - `K`: Kill container
    - `S`: Stop container
@@ -40,6 +42,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `↓`/`j`: Move down
    - `Enter`: View container logs
    - `d`: Navigate to dind process list (for dind containers)
+   - `f`: Browse container files
    - `p`: Switch to Docker container list view
    - `i`: Switch to Docker image list view
    - `n`: Switch to Docker network list view
@@ -102,6 +105,20 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `D`: Remove selected network (except default networks)
    - `Esc`/`q`: Back to Docker Compose process list
 
+10. **File Browser View**: Browse filesystem inside containers
+    - `↑`/`k`: Move up
+    - `↓`/`j`: Move down
+    - `Enter`: Open directory or view file
+    - `r`: Refresh list
+    - `Esc`/`q`: Back to container list
+
+11. **File Content View**: View file contents from containers
+    - `↑`/`k`: Scroll up
+    - `↓`/`j`: Scroll down
+    - `G`: Jump to end
+    - `g`: Jump to start
+    - `Esc`/`q`: Back to file browser
+
 ## Development Guidelines
 
 - Follow vim-style keybindings for all shortcuts
@@ -128,6 +145,7 @@ go build -o dcv
 - **Container inspect** - View detailed container configuration
 - **Container pause/unpause** - Temporarily freeze containers
 - **Container rename** - Change container names
+- **Download files from container** - Save container files locally
 
 ### Image Management
 - **Pull images** (`docker pull`) - Download new images

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ DCV is a TUI (Terminal User Interface) tool for monitoring Docker containers and
 - View all Docker containers (both standalone and Docker Compose managed)
 - List and manage Docker images
 - List and manage Docker networks
+- Browse files inside containers
 - List and manage Docker Compose containers
 - Switch between multiple Docker Compose projects
 - Real-time container log streaming (shows last 1000 lines, then follows new logs)
@@ -24,6 +25,7 @@ Displays `docker ps` results in a table format. Shows all Docker containers, not
 - `↑`/`k`: Move up
 - `↓`/`j`: Move down
 - `Enter`: View container logs
+- `f`: Browse container files
 - `a`: Toggle show all containers (including stopped)
 - `r`: Refresh list
 - `K`: Kill container
@@ -42,6 +44,7 @@ Displays `docker compose ps` results in a table format.
 - `↓`/`j`: Move down  
 - `Enter`: View container logs
 - `d`: View dind container contents (only for dind containers)
+- `f`: Browse container files
 - `p`: Switch to Docker container list view
 - `i`: Switch to Docker image list view
 - `n`: Switch to Docker network list view
@@ -96,6 +99,28 @@ Displays Docker networks with ID, name, driver, scope, and container count.
 - `r`: Refresh list
 - `D`: Remove selected network (except default networks)
 - `Esc`/`q`: Back to Docker Compose process list
+
+### File Browser View
+
+Browse the filesystem inside a container. Navigate directories and view file contents.
+
+**Key bindings:**
+- `↑`/`k`: Move up
+- `↓`/`j`: Move down
+- `Enter`: Open directory or view file
+- `r`: Refresh list
+- `Esc`/`q`: Back to container list
+
+### File Content View
+
+View the contents of a file from within a container.
+
+**Key bindings:**
+- `↑`/`k`: Scroll up
+- `↓`/`j`: Scroll down
+- `G`: Jump to end
+- `g`: Jump to start
+- `Esc`/`q`: Back to file browser
 
 ## Usage
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -386,3 +386,24 @@ func (c *Client) RemoveNetwork(networkID string) error {
 
 	return nil
 }
+
+func (c *Client) ListContainerFiles(containerID, path string) ([]models.ContainerFile, error) {
+	// Use ls -la to get detailed file information
+	output, err := c.executeCaptured("exec", containerID, "ls", "-la", path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files in container: %w\nOutput: %s", err, string(output))
+	}
+
+	files := models.ParseLsOutput(string(output))
+	return files, nil
+}
+
+func (c *Client) ReadContainerFile(containerID, path string) (string, error) {
+	// Use cat to read file contents
+	output, err := c.executeCaptured("exec", containerID, "cat", path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file in container: %w\nOutput: %s", err, string(output))
+	}
+
+	return string(output), nil
+}

--- a/internal/models/container_file.go
+++ b/internal/models/container_file.go
@@ -1,0 +1,77 @@
+package models
+
+import (
+	"strings"
+	"time"
+)
+
+// ContainerFile represents a file or directory in a container
+type ContainerFile struct {
+	Name        string
+	Size        int64
+	Mode        string
+	ModTime     time.Time
+	IsDir       bool
+	LinkTarget  string
+	Permissions string
+}
+
+// ParseLsOutput parses the output of ls -la command
+func ParseLsOutput(output string) []ContainerFile {
+	var files []ContainerFile
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	
+	for _, line := range lines {
+		if line == "" || strings.HasPrefix(line, "total") {
+			continue
+		}
+		
+		// Parse ls -la output format:
+		// drwxr-xr-x  2 root root 4096 Dec 15 10:30 dirname
+		// -rw-r--r--  1 root root  123 Dec 15 10:30 filename
+		parts := strings.Fields(line)
+		if len(parts) < 9 {
+			continue
+		}
+		
+		file := ContainerFile{
+			Permissions: parts[0],
+			Mode:        parts[0],
+			IsDir:       strings.HasPrefix(parts[0], "d"),
+		}
+		
+		// Parse size
+		if size := parts[4]; size != "" {
+			// Convert size string to int64 if needed
+			// For now, keep it simple
+		}
+		
+		// Get filename (handle spaces in filename)
+		// Everything from parts[8] onwards is the filename
+		file.Name = strings.Join(parts[8:], " ")
+		
+		// Handle symlinks (file -> target)
+		if strings.Contains(file.Name, " -> ") {
+			parts := strings.Split(file.Name, " -> ")
+			file.Name = parts[0]
+			if len(parts) > 1 {
+				file.LinkTarget = parts[1]
+			}
+		}
+		
+		files = append(files, file)
+	}
+	
+	return files
+}
+
+// GetDisplayName returns the display name with indicators
+func (f ContainerFile) GetDisplayName() string {
+	name := f.Name
+	if f.IsDir {
+		name += "/"
+	} else if f.LinkTarget != "" {
+		name += " -> " + f.LinkTarget
+	}
+	return name
+}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -14,6 +14,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"p"}, "docker ps", m.ShowDockerContainerList},
 		{[]string{"i"}, "docker images", m.ShowImageList},
 		{[]string{"n"}, "docker networks", m.ShowNetworkList},
+		{[]string{"f"}, "browse files", m.ShowFileBrowser},
 		{[]string{"r"}, "refresh", m.RefreshProcessList},
 		{[]string{"a"}, "toggle all", m.ToggleAllContainers},
 		{[]string{"s"}, "stats", m.ShowStatsView},
@@ -75,6 +76,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"up", "k"}, "move up", m.SelectUpDockerContainer},
 		{[]string{"down", "j"}, "move down", m.SelectDownDockerContainer},
 		{[]string{"enter"}, "view logs", m.ShowDockerLog},
+		{[]string{"f"}, "browse files", m.ShowDockerFileBrowser},
 		{[]string{"r"}, "refresh", m.RefreshDockerList},
 		{[]string{"a"}, "toggle all", m.ToggleAllDockerContainers},
 		{[]string{"K"}, "kill", m.KillDockerContainer},
@@ -107,6 +109,26 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"esc", "q"}, "back", m.BackFromNetworkList},
 	}
 	m.networkListViewKeymap = m.createKeymap(m.networkListViewHandlers)
+
+	// File Browser View
+	m.fileBrowserHandlers = []KeyConfig{
+		{[]string{"up", "k"}, "move up", m.SelectUpFile},
+		{[]string{"down", "j"}, "move down", m.SelectDownFile},
+		{[]string{"enter"}, "open", m.OpenFileOrDirectory},
+		{[]string{"r"}, "refresh", m.RefreshFiles},
+		{[]string{"esc", "q"}, "back", m.BackFromFileBrowser},
+	}
+	m.fileBrowserKeymap = m.createKeymap(m.fileBrowserHandlers)
+
+	// File Content View
+	m.fileContentHandlers = []KeyConfig{
+		{[]string{"up", "k"}, "scroll up", m.ScrollFileUp},
+		{[]string{"down", "j"}, "scroll down", m.ScrollFileDown},
+		{[]string{"G"}, "go to end", m.GoToFileEnd},
+		{[]string{"g"}, "go to start", m.GoToFileStart},
+		{[]string{"esc", "q"}, "back", m.BackFromFileContent},
+	}
+	m.fileContentKeymap = m.createKeymap(m.fileContentHandlers)
 
 	slog.Info("Initialized all view keymaps")
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -198,6 +198,32 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case containerFilesLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.containerFiles = msg.files
+		m.err = nil
+		if len(m.containerFiles) > 0 && m.selectedFile >= len(m.containerFiles) {
+			m.selectedFile = 0
+		}
+		return m, nil
+
+	case fileContentLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.fileContent = msg.content
+		m.fileContentPath = msg.path
+		m.fileScrollY = 0
+		m.err = nil
+		m.currentView = FileContentView
+		return m, nil
+
 	default:
 		return m, nil
 	}
@@ -247,6 +273,10 @@ func (m *Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleImageListKeys(msg)
 	case NetworkListView:
 		return m.handleNetworkListKeys(msg)
+	case FileBrowserView:
+		return m.handleFileBrowserKeys(msg)
+	case FileContentView:
+		return m.handleFileContentKeys(msg)
 	default:
 		return m, nil
 	}
@@ -347,6 +377,22 @@ func (m *Model) handleImageListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) handleNetworkListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	handler, ok := m.networkListViewKeymap[msg.String()]
+	if ok {
+		return handler(msg)
+	}
+	return m, nil
+}
+
+func (m *Model) handleFileBrowserKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	handler, ok := m.fileBrowserKeymap[msg.String()]
+	if ok {
+		return handler(msg)
+	}
+	return m, nil
+}
+
+func (m *Model) handleFileContentKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	handler, ok := m.fileContentKeymap[msg.String()]
 	if ok {
 		return handler(msg)
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -72,6 +72,10 @@ func (m *Model) View() string {
 		return m.renderImageList()
 	case NetworkListView:
 		return m.renderNetworkList()
+	case FileBrowserView:
+		return m.renderFileBrowser()
+	case FileContentView:
+		return m.renderFileContent()
 	default:
 		return "Unknown view"
 	}

--- a/internal/ui/view_filebrowser.go
+++ b/internal/ui/view_filebrowser.go
@@ -1,0 +1,145 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderFileBrowser renders the file browser view
+func (m *Model) renderFileBrowser() string {
+	var content strings.Builder
+
+	// Title
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	title := fmt.Sprintf("File Browser: %s [%s]", m.browsingContainerName, m.currentPath)
+	content.WriteString(titleStyle.Render(title))
+	content.WriteString("\n\n")
+
+	if m.loading {
+		return content.String() + "Loading files..."
+	}
+
+	if m.err != nil {
+		errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+		return content.String() + errorStyle.Render(fmt.Sprintf("Error: %v", m.err))
+	}
+
+	if len(m.containerFiles) == 0 {
+		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		return content.String() + dimStyle.Render("No files found or directory is empty")
+	}
+
+	// Table headers
+	headerStyle := lipgloss.NewStyle().Bold(true).Underline(true).Foreground(lipgloss.Color("86"))
+	headers := []string{"PERMISSIONS", "NAME"}
+	colWidths := []int{11, 60}
+
+	// Render headers
+	for i, header := range headers {
+		content.WriteString(headerStyle.Render(padRight(header, colWidths[i])))
+		if i < len(headers)-1 {
+			content.WriteString(" ")
+		}
+	}
+	content.WriteString("\n")
+
+	// Render files
+	normalStyle := lipgloss.NewStyle()
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("220")).Background(lipgloss.Color("235"))
+	dirStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("33"))
+	linkStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51"))
+
+	for i, file := range m.containerFiles {
+		style := normalStyle
+		nameStyle := normalStyle
+
+		if file.IsDir {
+			nameStyle = dirStyle
+		} else if file.LinkTarget != "" {
+			nameStyle = linkStyle
+		}
+
+		if i == m.selectedFile {
+			style = selectedStyle
+			nameStyle = selectedStyle
+		}
+
+		// Format row data
+		permissions := style.Render(padRight(file.Permissions, colWidths[0]))
+		name := nameStyle.Render(padRight(file.GetDisplayName(), colWidths[1]))
+
+		// Render row
+		content.WriteString(permissions)
+		content.WriteString(" ")
+		content.WriteString(name)
+		content.WriteString("\n")
+	}
+
+	// Show current path at bottom
+	pathStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Italic(true)
+	content.WriteString("\n")
+	content.WriteString(pathStyle.Render(fmt.Sprintf("Path: %s", m.currentPath)))
+
+	return content.String()
+}
+
+// renderFileContent renders the file content view
+func (m *Model) renderFileContent() string {
+	var content strings.Builder
+
+	// Title
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	title := fmt.Sprintf("File: %s [%s]", filepath.Base(m.fileContentPath), m.browsingContainerName)
+	content.WriteString(titleStyle.Render(title))
+	content.WriteString("\n\n")
+
+	if m.loading {
+		return content.String() + "Loading file content..."
+	}
+
+	if m.err != nil {
+		errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+		return content.String() + errorStyle.Render(fmt.Sprintf("Error: %v", m.err))
+	}
+
+	// File content with line numbers
+	lines := strings.Split(m.fileContent, "\n")
+	viewHeight := m.height - 5
+	startIdx := m.fileScrollY
+	endIdx := startIdx + viewHeight
+
+	if endIdx > len(lines) {
+		endIdx = len(lines)
+	}
+
+	lineNumStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	contentStyle := lipgloss.NewStyle()
+
+	if len(lines) == 0 {
+		content.WriteString("(empty file)\n")
+	} else if startIdx < len(lines) {
+		for i := startIdx; i < endIdx; i++ {
+			lineNum := lineNumStyle.Render(fmt.Sprintf("%4d ", i+1))
+			lineContent := contentStyle.Render(lines[i])
+			content.WriteString(lineNum + lineContent + "\n")
+		}
+	}
+
+	// Fill remaining space
+	linesShown := endIdx - startIdx
+	for i := linesShown; i < viewHeight; i++ {
+		content.WriteString("\n")
+	}
+
+	// Show position indicator
+	if len(lines) > viewHeight {
+		posStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		position := fmt.Sprintf("Lines %d-%d of %d", startIdx+1, endIdx, len(lines))
+		content.WriteString(posStyle.Render(position))
+	}
+
+	return content.String()
+}


### PR DESCRIPTION
## Summary
- Added comprehensive file browsing functionality for Docker containers
- Accessible via 'f' key from both Docker and Docker Compose container lists
- Allows users to explore container filesystems and view file contents

## Features
- **Directory Navigation**: Browse directories with `Enter` key, go up with `..`
- **File Viewing**: View text file contents with line numbers
- **Vim-style Navigation**: Consistent keybindings throughout
- **Path Display**: Shows current path and container name
- **File Type Indicators**: Directories shown with `/`, symlinks with `->`

## Implementation Details
- Added `ContainerFile` model to parse `ls -la` output
- Implemented `ListContainerFiles` and `ReadContainerFile` methods in Docker client
- Created `FileBrowserView` for directory navigation
- Created `FileContentView` for viewing file contents
- Full integration with existing MVU architecture
- Updated both README.md and CLAUDE.md documentation

## Test Plan
- [ ] Navigate to file browser with 'f' key from container list
- [ ] Test directory navigation (enter directories, go back with ..)
- [ ] View various text files
- [ ] Test scrolling in file content view (j/k, G/g)
- [ ] Verify path display shows correct location
- [ ] Test refresh functionality with 'r'
- [ ] Verify navigation back to container list with 'q' or 'Esc'

🤖 Generated with [Claude Code](https://claude.ai/code)