### PR TITLE
feat: add docker inspect view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
 - List and manage Docker networks
 - Browse files inside containers
 - Execute shell commands in containers
+- Inspect container configuration
 - Multiple Docker Compose project management and switching
 - Log viewing capability for any container
 - Special handling for dind (Docker-in-Docker) containers to view nested containers
@@ -30,6 +31,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `Enter`: View container logs
    - `f`: Browse container files
    - `!`: Execute /bin/sh in container
+   - `I`: Inspect container (view full config)
    - `a`: Toggle show all containers (including stopped)
    - `K`: Kill container
    - `S`: Stop container
@@ -46,6 +48,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `d`: Navigate to dind process list (for dind containers)
    - `f`: Browse container files
    - `!`: Execute /bin/sh in container
+   - `I`: Inspect container (view full config)
    - `p`: Switch to Docker container list view
    - `i`: Switch to Docker image list view
    - `n`: Switch to Docker network list view
@@ -122,6 +125,13 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
     - `g`: Jump to start
     - `Esc`/`q`: Back to file browser
 
+12. **Inspect View**: Shows full container configuration in JSON format
+    - `↑`/`k`: Scroll up
+    - `↓`/`j`: Scroll down
+    - `G`: Jump to end
+    - `g`: Jump to start
+    - `Esc`/`q`: Back to container list
+
 ## Development Guidelines
 
 - Follow vim-style keybindings for all shortcuts
@@ -144,7 +154,6 @@ go build -o dcv
 
 ### Container Management
 - **Copy files to/from containers** (`docker cp`)
-- **Container inspect** - View detailed container configuration
 - **Container pause/unpause** - Temporarily freeze containers
 - **Container rename** - Change container names
 - **Download files from container** - Save container files locally

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ DCV is a TUI (Terminal User Interface) tool for monitoring Docker containers and
 - List and manage Docker networks
 - Browse files inside containers
 - Execute shell commands in containers
+- Inspect container configuration
 - List and manage Docker Compose containers
 - Switch between multiple Docker Compose projects
 - Real-time container log streaming (shows last 1000 lines, then follows new logs)
@@ -28,6 +29,7 @@ Displays `docker ps` results in a table format. Shows all Docker containers, not
 - `Enter`: View container logs
 - `f`: Browse container files
 - `!`: Execute /bin/sh in container
+- `I`: Inspect container (view full config)
 - `a`: Toggle show all containers (including stopped)
 - `r`: Refresh list
 - `K`: Kill container
@@ -48,6 +50,7 @@ Displays `docker compose ps` results in a table format.
 - `d`: View dind container contents (only for dind containers)
 - `f`: Browse container files
 - `!`: Execute /bin/sh in container
+- `I`: Inspect container (view full config)
 - `p`: Switch to Docker container list view
 - `i`: Switch to Docker image list view
 - `n`: Switch to Docker network list view
@@ -124,6 +127,17 @@ View the contents of a file from within a container.
 - `G`: Jump to end
 - `g`: Jump to start
 - `Esc`/`q`: Back to file browser
+
+### Inspect View
+
+Displays the full Docker inspect output for a container in JSON format with syntax highlighting.
+
+**Key bindings:**
+- `↑`/`k`: Scroll up
+- `↓`/`j`: Scroll down
+- `G`: Jump to end
+- `g`: Jump to start
+- `Esc`/`q`: Back to container list
 
 ## Usage
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -427,3 +427,25 @@ func (c *Client) ExecuteInteractive(containerID string, command []string) error 
 	// Run the command
 	return cmd.Run()
 }
+
+func (c *Client) InspectContainer(containerID string) (string, error) {
+	output, err := c.executeCaptured("inspect", containerID)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect container: %w\nOutput: %s", err, string(output))
+	}
+	
+	// Pretty format the JSON output
+	var jsonData interface{}
+	if err := json.Unmarshal(output, &jsonData); err != nil {
+		// If we can't parse it, return raw output
+		return string(output), nil
+	}
+	
+	prettyJSON, err := json.MarshalIndent(jsonData, "", "  ")
+	if err != nil {
+		// If we can't pretty print, return raw output
+		return string(output), nil
+	}
+	
+	return string(prettyJSON), nil
+}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -16,6 +16,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"n"}, "docker networks", m.ShowNetworkList},
 		{[]string{"f"}, "browse files", m.ShowFileBrowser},
 		{[]string{"!"}, "exec /bin/sh", m.ExecuteShell},
+		{[]string{"I"}, "inspect", m.ShowInspect},
 		{[]string{"r"}, "refresh", m.RefreshProcessList},
 		{[]string{"a"}, "toggle all", m.ToggleAllContainers},
 		{[]string{"s"}, "stats", m.ShowStatsView},
@@ -79,6 +80,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"enter"}, "view logs", m.ShowDockerLog},
 		{[]string{"f"}, "browse files", m.ShowDockerFileBrowser},
 		{[]string{"!"}, "exec /bin/sh", m.ExecuteDockerShell},
+		{[]string{"I"}, "inspect", m.ShowDockerInspect},
 		{[]string{"r"}, "refresh", m.RefreshDockerList},
 		{[]string{"a"}, "toggle all", m.ToggleAllDockerContainers},
 		{[]string{"K"}, "kill", m.KillDockerContainer},
@@ -131,6 +133,16 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"esc", "q"}, "back", m.BackFromFileContent},
 	}
 	m.fileContentKeymap = m.createKeymap(m.fileContentHandlers)
+
+	// Inspect View
+	m.inspectViewHandlers = []KeyConfig{
+		{[]string{"up", "k"}, "scroll up", m.ScrollInspectUp},
+		{[]string{"down", "j"}, "scroll down", m.ScrollInspectDown},
+		{[]string{"G"}, "go to end", m.GoToInspectEnd},
+		{[]string{"g"}, "go to start", m.GoToInspectStart},
+		{[]string{"esc", "q"}, "back", m.BackFromInspect},
+	}
+	m.inspectViewKeymap = m.createKeymap(m.inspectViewHandlers)
 
 	slog.Info("Initialized all view keymaps")
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -39,6 +39,7 @@ const (
 	NetworkListView
 	FileBrowserView
 	FileContentView
+	InspectView
 )
 
 // Model represents the application state
@@ -88,6 +89,11 @@ type Model struct {
 	fileContent     string
 	fileContentPath string
 	fileScrollY     int
+
+	// Inspect view state
+	inspectContent     string
+	inspectScrollY     int
+	inspectContainerID string
 
 	// Log view state
 	logs          []string
@@ -143,6 +149,8 @@ type Model struct {
 	fileBrowserHandlers     []KeyConfig
 	fileContentKeymap       map[string]KeyHandler
 	fileContentHandlers     []KeyConfig
+	inspectViewKeymap       map[string]KeyHandler
+	inspectViewHandlers     []KeyConfig
 }
 
 // NewModel creates a new model with initial state
@@ -261,6 +269,11 @@ type fileContentLoadedMsg struct {
 type executeCommandMsg struct {
 	containerID string
 	command     []string
+}
+
+type inspectLoadedMsg struct {
+	content string
+	err     error
 }
 
 // Commands
@@ -490,6 +503,16 @@ func executeInteractiveCommand(containerID string, command []string) tea.Cmd {
 		return executeCommandMsg{
 			containerID: containerID,
 			command:     command,
+		}
+	}
+}
+
+func loadInspect(client *docker.Client, containerID string) tea.Cmd {
+	return func() tea.Msg {
+		content, err := client.InspectContainer(containerID)
+		return inspectLoadedMsg{
+			content: content,
+			err:     err,
 		}
 	}
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -233,6 +233,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return nil
 		})
 
+	case inspectLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.inspectContent = msg.content
+		m.inspectScrollY = 0
+		m.err = nil
+		m.currentView = InspectView
+		return m, nil
+
 	default:
 		return m, nil
 	}
@@ -286,6 +298,8 @@ func (m *Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleFileBrowserKeys(msg)
 	case FileContentView:
 		return m.handleFileContentKeys(msg)
+	case InspectView:
+		return m.handleInspectKeys(msg)
 	default:
 		return m, nil
 	}
@@ -402,6 +416,14 @@ func (m *Model) handleFileBrowserKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) handleFileContentKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	handler, ok := m.fileContentKeymap[msg.String()]
+	if ok {
+		return handler(msg)
+	}
+	return m, nil
+}
+
+func (m *Model) handleInspectKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	handler, ok := m.inspectViewKeymap[msg.String()]
 	if ok {
 		return handler(msg)
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -76,6 +76,8 @@ func (m *Model) View() string {
 		return m.renderFileBrowser()
 	case FileContentView:
 		return m.renderFileContent()
+	case InspectView:
+		return m.renderInspectView()
 	default:
 		return "Unknown view"
 	}

--- a/internal/ui/view_inspect.go
+++ b/internal/ui/view_inspect.go
@@ -1,0 +1,94 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderInspectView renders the container inspect view
+func (m *Model) renderInspectView() string {
+	var content strings.Builder
+
+	// Title
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	title := fmt.Sprintf("Container Inspect: %s", m.inspectContainerID)
+	content.WriteString(titleStyle.Render(title))
+	content.WriteString("\n\n")
+
+	if m.loading {
+		return content.String() + "Loading inspect data..."
+	}
+
+	if m.err != nil {
+		errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+		return content.String() + errorStyle.Render(fmt.Sprintf("Error: %v", m.err))
+	}
+
+	// Split content into lines for scrolling
+	lines := strings.Split(m.inspectContent, "\n")
+	viewHeight := m.height - 5
+	startIdx := m.inspectScrollY
+	endIdx := startIdx + viewHeight
+
+	if endIdx > len(lines) {
+		endIdx = len(lines)
+	}
+
+	// Render the JSON content with syntax highlighting
+	lineNumStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	jsonKeyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("33"))
+	jsonValueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("76"))
+	jsonBraceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+
+	if len(lines) == 0 {
+		content.WriteString("No inspect data available\n")
+	} else if startIdx < len(lines) {
+		for i := startIdx; i < endIdx; i++ {
+			line := lines[i]
+			lineNum := lineNumStyle.Render(fmt.Sprintf("%4d ", i+1))
+			
+			// Simple JSON syntax highlighting
+			highlightedLine := line
+			if strings.Contains(line, "\":") {
+				// This line likely contains a key-value pair
+				parts := strings.SplitN(line, "\":", 2)
+				if len(parts) == 2 {
+					// Extract key part
+					keyStart := strings.LastIndex(parts[0], "\"")
+					if keyStart >= 0 {
+						indent := parts[0][:keyStart]
+						key := parts[0][keyStart:]
+						value := parts[1]
+						
+						// Apply styles
+						highlightedLine = indent + jsonKeyStyle.Render(key+"\":") + jsonValueStyle.Render(value)
+					}
+				}
+			} else if strings.TrimSpace(line) == "{" || strings.TrimSpace(line) == "}" || 
+			          strings.TrimSpace(line) == "[" || strings.TrimSpace(line) == "]" ||
+			          strings.TrimSpace(line) == "}," || strings.TrimSpace(line) == "]," {
+				// Highlight braces and brackets
+				highlightedLine = jsonBraceStyle.Render(line)
+			}
+			
+			content.WriteString(lineNum + highlightedLine + "\n")
+		}
+	}
+
+	// Fill remaining space
+	linesShown := endIdx - startIdx
+	for i := linesShown; i < viewHeight; i++ {
+		content.WriteString("\n")
+	}
+
+	// Show position indicator
+	if len(lines) > viewHeight {
+		posStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		position := fmt.Sprintf("Lines %d-%d of %d", startIdx+1, endIdx, len(lines))
+		content.WriteString(posStyle.Render(position))
+	}
+
+	return content.String()
+}


### PR DESCRIPTION
## Summary
- Added container inspection functionality accessible via 'I' key
- Displays full container configuration in pretty-printed JSON format
- Includes syntax highlighting for better readability

## Features
- **Inspect View**: Press 'I' to view complete container configuration
- **JSON Syntax Highlighting**: Keys, values, and braces are color-coded
- **Line Numbers**: Each line numbered for easy reference
- **Vim-style Navigation**: Scroll with j/k, jump to start/end with g/G
- **Universal Support**: Works with both Docker and Docker Compose containers

## Implementation Details
- Added `InspectContainer` method to Docker client with JSON pretty-printing
- Created `InspectView` with custom JSON syntax highlighting
- Integrated with existing MVU architecture and navigation patterns
- Updated both README.md and CLAUDE.md documentation
- Removed "Container inspect" from missing features list

## Test Plan
- [ ] Navigate to container list and press 'I'
- [ ] Verify JSON is displayed with proper formatting
- [ ] Test scrolling with j/k keys
- [ ] Test jumping to start (g) and end (G)
- [ ] Verify syntax highlighting for JSON elements
- [ ] Test with both Docker and Docker Compose containers
- [ ] Exit with 'q' or 'Esc' and verify return to correct view

🤖 Generated with [Claude Code](https://claude.ai/code)