### PR TITLE
feat: implement enhanced vim-like search in log view

### DIFF
--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -109,6 +109,42 @@ func (m *Model) GoToLogStart(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m *Model) StartSearch(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.searchMode = true
 	m.searchText = ""
+	m.searchCursorPos = 0
+	m.searchResults = nil
+	m.currentSearchIdx = 0
+	return m, nil
+}
+
+func (m *Model) NextSearchResult(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.searchResults) > 0 {
+		m.currentSearchIdx = (m.currentSearchIdx + 1) % len(m.searchResults)
+		// Jump to the line
+		if m.currentSearchIdx < len(m.searchResults) {
+			targetLine := m.searchResults[m.currentSearchIdx]
+			m.logScrollY = targetLine - m.height/2 + 3 // Center the result
+			if m.logScrollY < 0 {
+				m.logScrollY = 0
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) PrevSearchResult(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.searchResults) > 0 {
+		m.currentSearchIdx--
+		if m.currentSearchIdx < 0 {
+			m.currentSearchIdx = len(m.searchResults) - 1
+		}
+		// Jump to the line
+		if m.currentSearchIdx < len(m.searchResults) {
+			targetLine := m.searchResults[m.currentSearchIdx]
+			m.logScrollY = targetLine - m.height/2 + 3 // Center the result
+			if m.logScrollY < 0 {
+				m.logScrollY = 0
+			}
+		}
+	}
 	return m, nil
 }
 

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -41,6 +41,8 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"G"}, "go to end", m.GoToLogEnd},
 		{[]string{"g"}, "go to start", m.GoToLogStart},
 		{[]string{"/"}, "search", m.StartSearch},
+		{[]string{"n"}, "next match", m.NextSearchResult},
+		{[]string{"N"}, "prev match", m.PrevSearchResult},
 		{[]string{"esc"}, "back", m.BackFromLogView},
 		{[]string{"?"}, "help", m.ShowHelp},
 	}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -185,6 +185,7 @@ func TestHandleSearchMode(t *testing.T) {
 			model: Model{
 				searchMode: true,
 				searchText: "err",
+				searchCursorPos: 3, // at end of "err"
 			},
 			key:            tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")},
 			wantSearchMode: true,
@@ -195,6 +196,7 @@ func TestHandleSearchMode(t *testing.T) {
 			model: Model{
 				searchMode: true,
 				searchText: "error",
+				searchCursorPos: 5, // at end of "error"
 			},
 			key:            tea.KeyMsg{Type: tea.KeyBackspace},
 			wantSearchMode: true,

--- a/internal/ui/view_log.go
+++ b/internal/ui/view_log.go
@@ -2,7 +2,10 @@ package ui
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 func (m *Model) renderLogView() string {
@@ -13,16 +16,8 @@ func (m *Model) renderLogView() string {
 		return s.String()
 	}
 
-	// Search mode indicator
-	if m.searchMode {
-		s.WriteString(searchStyle.Render(fmt.Sprintf("Search: %s", m.searchText)) + "\n\n")
-	}
-
 	// Calculate visible logs based on scroll position
-	visibleHeight := m.height - 4 // Account for title and help
-	if m.searchMode {
-		visibleHeight -= 2
-	}
+	visibleHeight := m.height - 4 // Account for title, footer, and borders
 
 	startIdx := m.logScrollY
 	endIdx := startIdx + visibleHeight
@@ -31,13 +26,34 @@ func (m *Model) renderLogView() string {
 		endIdx = len(m.logs)
 	}
 
+	// Define highlight style
+	highlightStyle := lipgloss.NewStyle().
+		Background(lipgloss.Color("226")).
+		Foreground(lipgloss.Color("235"))
+
 	// Display logs
 	if len(m.logs) == 0 {
 		s.WriteString("No logs available.\n")
 	} else {
 		for i := startIdx; i < endIdx; i++ {
 			if i < len(m.logs) {
-				s.WriteString(m.logs[i] + "\n")
+				line := m.logs[i]
+				
+				// Highlight search matches if we have results and search text
+				if m.searchText != "" && !m.searchMode {
+					line = m.highlightLine(line, highlightStyle)
+				}
+				
+				// Mark current search result line
+				if len(m.searchResults) > 0 && m.currentSearchIdx < len(m.searchResults) && 
+				   i == m.searchResults[m.currentSearchIdx] {
+					// Add a marker in the margin
+					s.WriteString("> ")
+				} else {
+					s.WriteString("  ")
+				}
+				
+				s.WriteString(line + "\n")
 			}
 		}
 	}
@@ -49,4 +65,64 @@ func (m *Model) renderLogView() string {
 	}
 
 	return s.String()
+}
+
+func (m *Model) highlightLine(line string, style lipgloss.Style) string {
+	if m.searchText == "" {
+		return line
+	}
+
+	if m.searchRegex {
+		pattern := m.searchText
+		if m.searchIgnoreCase {
+			pattern = "(?i)" + pattern
+		}
+		if re, err := regexp.Compile(pattern); err == nil {
+			// Find all matches
+			matches := re.FindAllStringIndex(line, -1)
+			if len(matches) == 0 {
+				return line
+			}
+			
+			// Build the line with highlights
+			var result strings.Builder
+			lastEnd := 0
+			for _, match := range matches {
+				start, end := match[0], match[1]
+				result.WriteString(line[lastEnd:start])
+				result.WriteString(style.Render(line[start:end]))
+				lastEnd = end
+			}
+			result.WriteString(line[lastEnd:])
+			return result.String()
+		}
+	} else {
+		// Simple string search
+		searchStr := m.searchText
+		lineToSearch := line
+		
+		if m.searchIgnoreCase {
+			searchStr = strings.ToLower(searchStr)
+			lineToSearch = strings.ToLower(line)
+		}
+		
+		// Find all occurrences
+		var result strings.Builder
+		lastEnd := 0
+		for {
+			idx := strings.Index(lineToSearch[lastEnd:], searchStr)
+			if idx == -1 {
+				break
+			}
+			
+			realIdx := lastEnd + idx
+			result.WriteString(line[lastEnd:realIdx])
+			result.WriteString(style.Render(line[realIdx:realIdx+len(m.searchText)]))
+			lastEnd = realIdx + len(m.searchText)
+		}
+		result.WriteString(line[lastEnd:])
+		return result.String()
+	}
+	
+	return line
 }

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -110,9 +110,10 @@ func TestView(t *testing.T) {
 				containerName: "web-1",
 				searchMode:    true,
 				searchText:    "error",
+				searchCursorPos: 5,
 			},
 			contains: []string{
-				"Search: error",
+				"/error", // Search prompt in footer
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
Implemented a comprehensive vim-like search feature for the log view with real-time highlighting and navigation.

## Features
- **Search UI at bottom**: Search prompt appears at the bottom of the terminal like vim (`/search_term`)
- **Navigation**: Use `n` for next match and `N` for previous match
- **Toggle options**:
  - `Ctrl-I`: Toggle case-insensitive search
  - `Ctrl-R`: Toggle regex search mode
- **Visual feedback**:
  - Search matches are highlighted with yellow background
  - Current match is marked with `>` in the margin
  - Search status shown in title bar with match count (e.g., "Search: 3/10 [ir]")
- **Real-time search**: Results update as you type
- **Smart scrolling**: View automatically scrolls to center the current match

## Demo
1. Press `Enter` on a container to view logs
2. Press `/` to start searching
3. Type your search term (results highlight in real-time)
4. Press `Enter` to confirm search
5. Use `n`/`N` to navigate between matches
6. Press `Ctrl-I` to toggle case sensitivity
7. Press `Ctrl-R` to enable regex mode

## Test plan
- [x] All existing tests pass
- [x] Updated tests for new search behavior
- [x] Manual testing with real container logs

🤖 Generated with [Claude Code](https://claude.ai/code)