### PR TITLE
refactor: centralize height calculations in viewBody

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -68,8 +68,20 @@ func (m *Model) View() string {
 		return lipgloss.JoinVertical(lipgloss.Left, titleStyle.Render(title), body)
 	}
 
-	// Get body content
-	body := m.viewBody()
+	// Calculate available height for body content
+	// Layout: title (with margin) + body + footer
+	titleRendered := titleStyle.Render(title)
+	actualTitleHeight := lipgloss.Height(titleRendered)
+	footerHeight := 1
+	
+	// Available height = total height - title height - footer height
+	availableBodyHeight := m.height - actualTitleHeight - footerHeight
+	if availableBodyHeight < 1 {
+		availableBodyHeight = 1
+	}
+
+	// Get body content with available height
+	body := m.viewBody(availableBodyHeight)
 	bodyHeight := strings.Count(body, "\n") + 1
 
 	// Special handling for HelpView (it has its own footer)
@@ -83,7 +95,6 @@ func (m *Model) View() string {
 
 	// Build footer content (command line or quit confirmation or help hint)
 	var footer string
-	footerHeight := 1
 	
 	if m.quitConfirmation {
 		// Show quit confirmation dialog
@@ -220,34 +231,34 @@ func (m *Model) viewTitle() string {
 	}
 }
 
-func (m *Model) viewBody() string {
+func (m *Model) viewBody(availableHeight int) string {
 	switch m.currentView {
 	case ComposeProcessListView:
-		return m.renderComposeProcessList()
+		return m.renderComposeProcessList(availableHeight)
 	case LogView:
-		return m.renderLogView()
+		return m.renderLogView(availableHeight)
 	case DindComposeProcessListView:
-		return m.renderDindList()
+		return m.renderDindList(availableHeight)
 	case TopView:
-		return m.renderTopView()
+		return m.renderTopView(availableHeight)
 	case StatsView:
-		return m.renderStatsView()
+		return m.renderStatsView(availableHeight)
 	case ProjectListView:
-		return m.renderProjectList()
+		return m.renderProjectList(availableHeight)
 	case DockerContainerListView:
-		return m.renderDockerList()
+		return m.renderDockerList(availableHeight)
 	case ImageListView:
-		return m.renderImageList()
+		return m.renderImageList(availableHeight)
 	case NetworkListView:
-		return m.renderNetworkList()
+		return m.renderNetworkList(availableHeight)
 	case FileBrowserView:
-		return m.renderFileBrowser()
+		return m.renderFileBrowser(availableHeight)
 	case FileContentView:
-		return m.renderFileContent()
+		return m.renderFileContent(availableHeight)
 	case InspectView:
-		return m.renderInspectView()
+		return m.renderInspectView(availableHeight)
 	case HelpView:
-		return m.renderHelpView()
+		return m.renderHelpView(availableHeight)
 	default:
 		return "Unknown view"
 	}

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 )
 
-func (m *Model) renderComposeProcessList() string {
+func (m *Model) renderComposeProcessList(availableHeight int) string {
 	var s strings.Builder
 
 	slog.Info("Rendering container list",
@@ -36,7 +36,7 @@ func (m *Model) renderComposeProcessList() string {
 			return normalStyle
 		}).
 		Headers("SERVICE", "IMAGE", "STATUS", "PORTS").
-		Height(m.height - 4). // Reserve space for footer
+		Height(availableHeight).
 		Width(m.width).
 		Offset(m.selectedDockerImage)
 

--- a/internal/ui/view_dind_compose_process_list.go
+++ b/internal/ui/view_dind_compose_process_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 )
 
-func (m *Model) renderDindList() string {
+func (m *Model) renderDindList(availableHeight int) string {
 	var s strings.Builder
 
 	if len(m.dindContainers) == 0 {

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 )
 
-func (m *Model) renderDockerList() string {
+func (m *Model) renderDockerList(availableHeight int) string {
 	var s strings.Builder
 
 	if len(m.dockerContainers) == 0 {

--- a/internal/ui/view_file_browser.go
+++ b/internal/ui/view_file_browser.go
@@ -9,7 +9,7 @@ import (
 )
 
 // renderFileBrowser renders the file browser view
-func (m *Model) renderFileBrowser() string {
+func (m *Model) renderFileBrowser(availableHeight int) string {
 	var content strings.Builder
 
 	if len(m.containerFiles) == 0 {
@@ -34,7 +34,7 @@ func (m *Model) renderFileBrowser() string {
 			return normalStyle
 		}).
 		Headers("PERMISSIONS", "NAME").
-		Height(m.height - 6). // Reserve space for title, footer, and path
+		Height(availableHeight - 3). // Reserve 3 lines for path display
 		Width(m.width).
 		Offset(m.selectedFile)
 

--- a/internal/ui/view_file_content.go
+++ b/internal/ui/view_file_content.go
@@ -8,7 +8,7 @@ import (
 )
 
 // renderFileContent renders the file content view
-func (m *Model) renderFileContent() string {
+func (m *Model) renderFileContent(availableHeight int) string {
 	var content strings.Builder
 
 	if m.err != nil {
@@ -18,7 +18,7 @@ func (m *Model) renderFileContent() string {
 
 	// File content with line numbers
 	lines := strings.Split(m.fileContent, "\n")
-	viewHeight := m.height - 5
+	viewHeight := availableHeight
 	startIdx := m.fileScrollY
 	endIdx := startIdx + viewHeight
 

--- a/internal/ui/view_help.go
+++ b/internal/ui/view_help.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func (m *Model) renderHelpView() string {
+func (m *Model) renderHelpView(availableHeight int) string {
 	var s strings.Builder
 
 	// Get key configurations based on previous view
@@ -58,7 +58,7 @@ func (m *Model) renderHelpView() string {
 
 	// Calculate max scroll
 	totalLines := len(configs) + 5 // title + view name + margins
-	visibleLines := m.height - 4   // footer + margins
+	visibleLines := availableHeight - 4   // footer + margins
 	maxScroll := totalLines - visibleLines
 	if maxScroll < 0 {
 		maxScroll = 0
@@ -95,7 +95,7 @@ func (m *Model) renderHelpView() string {
 	// Footer
 	footer := "\n" + helpStyle.Render("Press ESC or q to go back")
 	footerHeight := 2
-	contentHeight := m.height - footerHeight
+	contentHeight := availableHeight - footerHeight
 	currentHeight := strings.Count(s.String(), "\n") + 1
 	if currentHeight < contentHeight {
 		s.WriteString(strings.Repeat("\n", contentHeight-currentHeight))

--- a/internal/ui/view_image_list.go
+++ b/internal/ui/view_image_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 )
 
-func (m *Model) renderImageList() string {
+func (m *Model) renderImageList(availableHeight int) string {
 	var s strings.Builder
 
 	// No images
@@ -20,7 +20,7 @@ func (m *Model) renderImageList() string {
 	// Create table
 	t := table.New().
 		Headers("REPOSITORY", "TAG", "IMAGE ID", "CREATED", "SIZE").
-		Height(m.height - 4). // Reserve space for footer
+		Height(availableHeight).
 		Width(m.width).
 		Offset(m.selectedDockerImage)
 

--- a/internal/ui/view_inspect.go
+++ b/internal/ui/view_inspect.go
@@ -8,12 +8,12 @@ import (
 )
 
 // renderInspectView renders the container inspect view
-func (m *Model) renderInspectView() string {
+func (m *Model) renderInspectView(availableHeight int) string {
 	var content strings.Builder
 
 	// Split content into lines for scrolling
 	lines := strings.Split(m.inspectContent, "\n")
-	viewHeight := m.height - 5
+	viewHeight := availableHeight
 	startIdx := m.inspectScrollY
 	endIdx := startIdx + viewHeight
 

--- a/internal/ui/view_log.go
+++ b/internal/ui/view_log.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func (m *Model) renderLogView() string {
+func (m *Model) renderLogView(availableHeight int) string {
 	var s strings.Builder
 
 	if m.loading && len(m.logs) == 0 {
@@ -17,7 +17,7 @@ func (m *Model) renderLogView() string {
 	}
 
 	// Calculate visible logs based on scroll position
-	visibleHeight := m.height - 4 // Account for title, footer, and borders
+	visibleHeight := availableHeight
 
 	startIdx := m.logScrollY
 	endIdx := startIdx + visibleHeight

--- a/internal/ui/view_network_list.go
+++ b/internal/ui/view_network_list.go
@@ -8,7 +8,7 @@ import (
 )
 
 // renderNetworkList renders the network list view
-func (m *Model) renderNetworkList() string {
+func (m *Model) renderNetworkList(availableHeight int) string {
 	var content strings.Builder
 
 	if len(m.dockerNetworks) == 0 {

--- a/internal/ui/view_project_list.go
+++ b/internal/ui/view_project_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 )
 
-func (m *Model) renderProjectList() string {
+func (m *Model) renderProjectList(availableHeight int) string {
 	var s strings.Builder
 
 	if len(m.projects) == 0 {
@@ -28,7 +28,7 @@ func (m *Model) renderProjectList() string {
 			return normalStyle
 		}).
 		Headers("NAME", "STATUS", "CONFIG FILES").
-		Height(m.height - 4). // Reserve space for footer
+		Height(availableHeight).
 		Width(m.width).
 		Offset(m.selectedDockerImage)
 

--- a/internal/ui/view_stats.go
+++ b/internal/ui/view_stats.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 )
 
-func (m *Model) renderStatsView() string {
+func (m *Model) renderStatsView(availableHeight int) string {
 	var s strings.Builder
 
 	if len(m.stats) == 0 {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -176,7 +176,9 @@ func TestRenderProcessList(t *testing.T) {
 		selectedContainer: 0,
 	}
 
-	view := m.renderComposeProcessList()
+	// Calculate available height (height - title - footer)
+	availableHeight := m.height - 2
+	view := m.renderComposeProcessList(availableHeight)
 
 	// Check that the selected row is highlighted
 	assert.Contains(t, view, "web")
@@ -202,14 +204,16 @@ func TestRenderLogView(t *testing.T) {
 		logScrollY: 0,
 	}
 
-	view := m.renderLogView()
+	// Calculate available height
+	availableHeight := m.height - 2
+	view := m.renderLogView(availableHeight)
 
 	// Should show logs
 	assert.Contains(t, view, "Line 1")
 
 	// Test scrolling
 	m.logScrollY = 2
-	view = m.renderLogView()
+	view = m.renderLogView(availableHeight)
 	assert.NotContains(t, view, "Line 1")
 	assert.Contains(t, view, "Line 3")
 }
@@ -238,7 +242,9 @@ func TestRenderDindList(t *testing.T) {
 		selectedDindContainer: 1,
 	}
 
-	view := m.renderDindList()
+	// Calculate available height
+	availableHeight := m.height - 2
+	view := m.renderDindList(availableHeight)
 
 	// The title is in viewTitle(), not renderDindList()
 	// Check that dind containers are listed correctly
@@ -259,7 +265,9 @@ func TestViewWithNoContainers(t *testing.T) {
 		composeContainers: []models.ComposeContainer{},
 	}
 
-	view := m.renderComposeProcessList()
+	// Calculate available height
+	availableHeight := m.height - 2
+	view := m.renderComposeProcessList(availableHeight)
 	assert.Contains(t, view, "No containers found")
 	assert.Contains(t, view, "Press u to start services or p to switch to project list")
 }
@@ -280,7 +288,9 @@ func TestTableRendering(t *testing.T) {
 		},
 	}
 
-	view := m.renderComposeProcessList()
+	// Calculate available height
+	availableHeight := m.height - 2
+	view := m.renderComposeProcessList(availableHeight)
 
 	// Check for table borders
 	lines := strings.Split(view, "\n")

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-func (m *Model) renderTopView() string {
+func (m *Model) renderTopView(availableHeight int) string {
 	var s strings.Builder
 
 	if m.topOutput == "" {
@@ -12,7 +12,7 @@ func (m *Model) renderTopView() string {
 	} else {
 		// Display the raw top output
 		lines := strings.Split(m.topOutput, "\n")
-		visibleHeight := m.height - 2 // Account for margins
+		visibleHeight := availableHeight
 
 		for i, line := range lines {
 			if i >= visibleHeight {


### PR DESCRIPTION
## Summary
- Centralized height calculations from individual render functions to the main View() method
- All render functions now receive the calculated available height as a parameter
- Removed hardcoded height offsets throughout the codebase

## Why this change?
Previously, each rendering function calculated its own available height using formulas like:
- `m.height - 4` (most table views)
- `m.height - 6` (file browser)
- `m.height - 2` (simple views)

This made it difficult to:
1. Understand how height was being distributed
2. Make consistent changes to layout spacing
3. Maintain the code when adding new views

## Changes
- Modified `viewBody()` to accept `availableHeight int` parameter
- Updated all render functions to accept `availableHeight int` parameter
- Centralized height calculation in `View()` method:
  ```go
  availableBodyHeight := m.height - actualTitleHeight - footerHeight
  ```
- Updated tests to pass calculated height when calling render functions directly

## Benefits
- **Consistency**: All views now use the same height calculation logic
- **Maintainability**: Easier to adjust spacing by changing calculation in one place
- **Clarity**: Clear understanding of how terminal height is distributed among UI components
- **Flexibility**: Easier to add dynamic sizing features in the future

## Test plan
- [x] All existing tests pass
- [x] Manual testing shows views render correctly at different terminal sizes
- [x] Table views properly display with correct height
- [x] Non-table views (logs, top, stats) work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)