### PR TITLE
feat: add network inspect feature and enhance docker-compose.yml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
 9. **Network List View**: Shows Docker networks with ID, name, driver, scope, and container count
    - `↑`/`k`: Move up
    - `↓`/`j`: Move down
+   - `I`: Inspect network (view full config)
    - `r`: Refresh list
    - `D`: Remove selected network (except default networks)
    - `Esc`/`q`: Back to Docker Compose process list

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Displays Docker networks with ID, name, driver, scope, and container count.
 **Key bindings:**
 - `↑`/`k`: Move up
 - `↓`/`j`: Move down
+- `I`: Inspect network (view full config)
 - `r`: Refresh list
 - `D`: Remove selected network (except default networks)
 - `?`: Show help view

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     volumes:
       - ./html:/usr/share/nginx/html:ro
     networks:
-      - dcv-network
+      - frontend
+      - backend  # Needs to connect to backend services
 
   # Database
   db:
@@ -19,7 +20,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:
-      - dcv-network
+      - backend  # Only on backend network
 
   # Redis cache
   redis:
@@ -28,7 +29,7 @@ services:
     volumes:
       - redis-data:/data
     networks:
-      - dcv-network
+      - backend  # Only on backend network
 
   # Docker in Docker for CI/CD simulation
   dind:
@@ -41,7 +42,7 @@ services:
       - ./dind-startup.sh:/startup.sh:ro
       - ./dind-entrypoint.sh:/entrypoint.sh:ro
     networks:
-      - dcv-network
+      - development  # On isolated development network
     entrypoint: ["/entrypoint.sh"]
     command: ["dockerd", "--host=unix:///var/run/docker.sock", "--host=tcp://0.0.0.0:2375"]
 
@@ -62,7 +63,32 @@ services:
         done
       "
     networks:
-      - dcv-network
+      - monitoring  # On monitoring network
+
+  # API Gateway service
+  api-gateway:
+    image: nginx:alpine
+    ports:
+      - "8091:80"
+    networks:
+      - frontend
+      - backend
+      - monitoring
+    volumes:
+      - ./nginx-api.conf:/etc/nginx/nginx.conf:ro
+
+  # Cache warmer service
+  cache-warmer:
+    image: alpine:latest
+    command: |
+      sh -c "
+        while true; do
+          echo \"[$(date '+%Y-%m-%d %H:%M:%S')] Warming cache...\"
+          sleep 30
+        done
+      "
+    networks:
+      - backend  # Needs access to cache
 
 volumes:
   postgres-data:
@@ -70,5 +96,44 @@ volumes:
   dind-storage:
 
 networks:
+  # Default bridge network for main services
   dcv-network:
     driver: bridge
+    name: dcv-main-network
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+          gateway: 172.20.0.1
+
+  # Frontend network (web-facing services)
+  frontend:
+    driver: bridge
+    name: dcv-frontend
+    ipam:
+      config:
+        - subnet: 172.21.0.0/16
+          gateway: 172.21.0.1
+
+  # Backend network (database and cache)
+  backend:
+    driver: bridge
+    name: dcv-backend
+    ipam:
+      config:
+        - subnet: 172.22.0.0/16
+          gateway: 172.22.0.1
+
+  # Monitoring network (for future monitoring services)
+  monitoring:
+    driver: bridge
+    name: dcv-monitoring
+    ipam:
+      config:
+        - subnet: 172.23.0.0/16
+          gateway: 172.23.0.1
+
+  # Development network (for dind and testing)
+  development:
+    driver: bridge
+    name: dcv-development
+    internal: true  # This network has no external access

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -497,3 +497,25 @@ func (c *Client) InspectImage(imageID string) (string, error) {
 
 	return string(prettyJSON), nil
 }
+
+func (c *Client) InspectNetwork(networkID string) (string, error) {
+	output, err := c.executeCaptured("network", "inspect", networkID)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect network: %w\nOutput: %s", err, string(output))
+	}
+
+	// Pretty format the JSON output
+	var jsonData interface{}
+	if err := json.Unmarshal(output, &jsonData); err != nil {
+		// If we can't parse it, return raw output
+		return string(output), nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(jsonData, "", "  ")
+	if err != nil {
+		// If we can't pretty print, return raw output
+		return string(output), nil
+	}
+
+	return string(prettyJSON), nil
+}

--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -636,6 +636,18 @@ func (m *Model) DeleteNetwork(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m *Model) ShowNetworkInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectedDockerNetwork < len(m.dockerNetworks) {
+		network := m.dockerNetworks[m.selectedDockerNetwork]
+		m.inspectNetworkID = network.ID
+		m.inspectContainerID = "" // Clear container ID
+		m.inspectImageID = ""     // Clear image ID
+		m.loading = true
+		return m, loadNetworkInspect(m.dockerClient, network.ID)
+	}
+	return m, nil
+}
+
 func (m *Model) BackFromNetworkList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.currentView = ComposeProcessListView
 	return m, loadProcesses(m.dockerClient, m.projectName, m.showAll)
@@ -869,6 +881,13 @@ func (m *Model) BackFromInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.inspectImageID != "" {
 		m.currentView = ImageListView
 		m.inspectImageID = ""
+		return m, nil
+	}
+
+	// Check if we were inspecting a network
+	if m.inspectNetworkID != "" {
+		m.currentView = NetworkListView
+		m.inspectNetworkID = ""
 		return m, nil
 	}
 

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -145,6 +145,7 @@ func (m *Model) initializeKeyHandlers() {
 	m.networkListViewHandlers = []KeyConfig{
 		{[]string{"up", "k"}, "move up", m.SelectUpNetwork},
 		{[]string{"down", "j"}, "move down", m.SelectDownNetwork},
+		{[]string{"I"}, "inspect", m.ShowNetworkInspect},
 		{[]string{"r"}, "refresh", m.RefreshNetworkList},
 		{[]string{"D"}, "remove", m.DeleteNetwork},
 		{[]string{"1"}, "docker ps", m.ShowDockerContainerList},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -97,6 +97,7 @@ type Model struct {
 	inspectScrollY     int
 	inspectContainerID string
 	inspectImageID     string
+	inspectNetworkID   string
 
 	// Log view state
 	logs          []string
@@ -620,6 +621,16 @@ func loadInspect(client *docker.Client, containerID string) tea.Cmd {
 func loadImageInspect(client *docker.Client, imageID string) tea.Cmd {
 	return func() tea.Msg {
 		content, err := client.InspectImage(imageID)
+		return inspectLoadedMsg{
+			content: content,
+			err:     err,
+		}
+	}
+}
+
+func loadNetworkInspect(client *docker.Client, networkID string) tea.Cmd {
+	return func() tea.Msg {
+		content, err := client.InspectNetwork(networkID)
 		return inspectLoadedMsg{
 			content: content,
 			err:     err,

--- a/nginx-api.conf
+++ b/nginx-api.conf
@@ -1,0 +1,22 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            return 200 'API Gateway is running\n';
+            add_header Content-Type text/plain;
+        }
+
+        location /health {
+            return 200 'OK\n';
+            add_header Content-Type text/plain;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added network inspect feature to view detailed network configuration
- Enhanced docker-compose.yml with multiple networks to better demonstrate network view capabilities
- Updated documentation to reflect the new network inspect feature

## Changes
1. **Network Inspect Feature**
   - Added 'I' key binding in network list view to inspect selected network
   - Implemented `InspectNetwork` method in docker client
   - Updated `BackFromInspect` handler to properly return to network list view
   - Added `ShowNetworkInspect` handler in keyhandler.go

2. **Enhanced docker-compose.yml**
   - Added multiple networks: frontend, backend, monitoring, development
   - Added new services: api-gateway (nginx) and cache-warmer (alpine)
   - Configured services to use appropriate networks

3. **Documentation Updates**
   - Updated README.md to include network inspect key binding
   - Updated CLAUDE.md to document network inspect feature

## Test plan
- [x] Build project successfully
- [x] All tests pass
- [x] Network list view shows networks correctly
- [x] 'I' key opens network inspect view
- [x] Escape/q returns from inspect view to network list
- [x] Enhanced docker-compose.yml creates multiple networks

🤖 Generated with [Claude Code](https://claude.ai/code)