### PR TITLE
feat: change network inspect shortcut from 'I' to 'Enter'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
 9. **Network List View**: Shows Docker networks with ID, name, driver, scope, and container count
    - `↑`/`k`: Move up
    - `↓`/`j`: Move down
-   - `I`: Inspect network (view full config)
+   - `Enter`: Inspect network (view full config)
    - `r`: Refresh list
    - `D`: Remove selected network (except default networks)
    - `Esc`/`q`: Back to Docker Compose process list

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Displays Docker networks with ID, name, driver, scope, and container count.
 **Key bindings:**
 - `↑`/`k`: Move up
 - `↓`/`j`: Move down
-- `I`: Inspect network (view full config)
+- `Enter`: Inspect network (view full config)
 - `r`: Refresh list
 - `D`: Remove selected network (except default networks)
 - `?`: Show help view

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -145,7 +145,7 @@ func (m *Model) initializeKeyHandlers() {
 	m.networkListViewHandlers = []KeyConfig{
 		{[]string{"up", "k"}, "move up", m.SelectUpNetwork},
 		{[]string{"down", "j"}, "move down", m.SelectDownNetwork},
-		{[]string{"I"}, "inspect", m.ShowNetworkInspect},
+		{[]string{"enter"}, "inspect", m.ShowNetworkInspect},
 		{[]string{"r"}, "refresh", m.RefreshNetworkList},
 		{[]string{"D"}, "remove", m.DeleteNetwork},
 		{[]string{"1"}, "docker ps", m.ShowDockerContainerList},


### PR DESCRIPTION
## Summary
Changed the network inspect key binding from 'I' to 'Enter' to make it more intuitive and consistent with other views.

## Changes
- Updated key binding in `keymap.go` from 'I' to 'Enter' for network inspect
- Updated documentation in README.md
- Updated documentation in CLAUDE.md

## Rationale
- Enter is the primary action key in list views throughout the application
- Network inspect is the primary operation for the network list view
- This makes the interface more intuitive and consistent

## Test plan
- [x] All tests pass
- [x] Enter key now opens network inspect view
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)