### PR TITLE
feat: add Docker volume list and inspect functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
 - List view of all Docker containers (both plain Docker and Docker Compose managed)
 - List and manage Docker images
 - List and manage Docker networks
+- List and manage Docker volumes
 - Browse files inside containers
 - Execute shell commands in containers
 - Inspect container configuration
@@ -129,7 +130,17 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
    - `D`: Remove selected network (except default networks)
    - `Esc`/`q`: Back to Docker Compose process list
 
-10. **File Browser View**: Browse filesystem inside containers
+10. **Volume List View**: Shows Docker volumes with name, driver, scope, size, creation date, and reference count
+    - `↑`/`k`: Move up
+    - `↓`/`j`: Move down
+    - `Enter`: Inspect volume (view full config)
+    - `r`: Refresh list
+    - `D`: Remove selected volume
+    - `F`: Force remove selected volume
+    - `1`/`2`/`3`/`4`: Switch to other views
+    - `Esc`/`q`: Back to Docker Compose process list
+
+11. **File Browser View**: Browse filesystem inside containers
     - `↑`/`k`: Move up
     - `↓`/`j`: Move down
     - `Enter`: Open directory or view file
@@ -138,7 +149,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
     - `?`: Show help view
     - `Esc`/`q`: Back to container list
 
-11. **File Content View**: View file contents from containers
+12. **File Content View**: View file contents from containers
     - `↑`/`k`: Scroll up
     - `↓`/`j`: Scroll down
     - `G`: Jump to end
@@ -146,7 +157,7 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
     - `?`: Show help view
     - `Esc`/`q`: Back to file browser
 
-12. **Inspect View**: Shows full container configuration in JSON format
+13. **Inspect View**: Shows full container configuration in JSON format
     - `↑`/`k`: Scroll up
     - `↓`/`j`: Scroll down
     - `G`: Jump to end
@@ -154,12 +165,12 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
     - `?`: Show help view
     - `Esc`/`q`: Back to container list
 
-13. **Help View**: Displays all available keyboard shortcuts for the current view
+14. **Help View**: Displays all available keyboard shortcuts for the current view
     - `↑`/`k`: Scroll up
     - `↓`/`j`: Scroll down
     - `Esc`/`q`: Back to previous view
 
-14. **Command Mode**: Vim-style command line interface
+15. **Command Mode**: Vim-style command line interface
     - `:q` or `:quit`: Quit with confirmation
     - `:q!` or `:quit!`: Force quit without confirmation
     - `:help commands`: List all available commands

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ DCV is a TUI (Terminal User Interface) tool for monitoring Docker containers and
 - View all Docker containers (both standalone and Docker Compose managed)
 - List and manage Docker images
 - List and manage Docker networks
+- List and manage Docker volumes with size information
 - Browse files inside containers
 - Execute shell commands in containers
 - Inspect container configuration

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -493,3 +493,4 @@ func (c *Client) InspectNetwork(networkID string) (string, error) {
 
 	return string(prettyJSON), nil
 }
+

--- a/internal/docker/volume.go
+++ b/internal/docker/volume.go
@@ -1,0 +1,133 @@
+package docker
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/tokuhirom/dcv/internal/models"
+)
+
+// ListVolumes lists all Docker volumes
+func (c *Client) ListVolumes() ([]models.DockerVolume, error) {
+	// Use docker volume ls with JSON format
+	output, err := c.executeCaptured("volume", "ls", "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute docker volume ls: %w\nOutput: %s", err, string(output))
+	}
+
+	// Handle empty output
+	if len(output) == 0 || string(output) == "" || string(output) == "\n" {
+		slog.Info("No volumes found")
+		return []models.DockerVolume{}, nil
+	}
+
+	// Parse line-delimited JSON
+	volumes := make([]models.DockerVolume, 0)
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var volume models.DockerVolume
+		if err := json.Unmarshal(line, &volume); err != nil {
+			slog.Warn("Failed to parse volume JSON",
+				slog.String("line", string(line)),
+				slog.String("error", err.Error()))
+			continue
+		}
+
+		volumes = append(volumes, volume)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error scanning volume output: %w", err)
+	}
+
+	// Get size information using docker system df
+	sizeInfo, err := c.getVolumeSizes()
+	if err != nil {
+		slog.Warn("Failed to get volume sizes", slog.String("error", err.Error()))
+	} else {
+		// Map sizes to volumes
+		sizeMap := make(map[string]models.DockerVolumeSize)
+		for _, size := range sizeInfo {
+			sizeMap[size.Name] = size
+		}
+		
+		for i := range volumes {
+			if size, ok := sizeMap[volumes[i].Name]; ok {
+				volumes[i].Size = size.Size
+				volumes[i].RefCount = size.RefCount
+			}
+		}
+	}
+
+	return volumes, nil
+}
+
+// getVolumeSizes gets volume size information using docker system df
+func (c *Client) getVolumeSizes() ([]models.DockerVolumeSize, error) {
+	output, err := c.executeCaptured("system", "df", "--format", "json", "-v")
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute docker system df: %w", err)
+	}
+
+	var systemDf struct {
+		Volumes []models.DockerVolumeSize `json:"Volumes"`
+	}
+	
+	if err := json.Unmarshal(output, &systemDf); err != nil {
+		return nil, fmt.Errorf("failed to parse docker system df output: %w", err)
+	}
+
+	return systemDf.Volumes, nil
+}
+
+// RemoveVolume removes a Docker volume
+func (c *Client) RemoveVolume(volumeName string, force bool) error {
+	args := []string{"volume", "rm"}
+	if force {
+		args = append(args, "-f")
+	}
+	args = append(args, volumeName)
+
+	output, err := c.executeCaptured(args...)
+	if err != nil {
+		return fmt.Errorf("failed to remove volume %s: %w\nOutput: %s", volumeName, err, string(output))
+	}
+
+	slog.Info("Removed volume",
+		slog.String("volumeName", volumeName),
+		slog.String("output", string(output)))
+
+	return nil
+}
+
+// InspectVolume inspects a Docker volume and returns the formatted JSON
+func (c *Client) InspectVolume(volumeName string) (string, error) {
+	output, err := c.executeCaptured("volume", "inspect", volumeName)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect volume %s: %w\nOutput: %s", volumeName, err, string(output))
+	}
+
+	// Pretty format the JSON output
+	var jsonData interface{}
+	if err := json.Unmarshal(output, &jsonData); err != nil {
+		// If we can't parse it, return raw output
+		return string(output), nil
+	}
+
+	prettyJSON, err := json.MarshalIndent(jsonData, "", "  ")
+	if err != nil {
+		// If we can't pretty print, return raw output
+		return string(output), nil
+	}
+
+	return string(prettyJSON), nil
+}

--- a/internal/models/volume.go
+++ b/internal/models/volume.go
@@ -1,0 +1,36 @@
+package models
+
+import "time"
+
+// DockerVolume represents a Docker volume
+type DockerVolume struct {
+	Name       string            `json:"Name"`
+	Driver     string            `json:"Driver"`
+	Mountpoint string            `json:"Mountpoint"`
+	CreatedAt  time.Time         `json:"CreatedAt"`
+	Scope      string            `json:"Scope"`
+	Labels     map[string]string `json:"Labels"`
+	Options    map[string]string `json:"Options"`
+	Size       int64             `json:"-"` // Size in bytes, populated separately
+	RefCount   int               `json:"-"` // Reference count, populated separately
+}
+
+// GetLabel returns a label value by key, or empty string if not found
+func (v DockerVolume) GetLabel(key string) string {
+	if v.Labels == nil {
+		return ""
+	}
+	return v.Labels[key]
+}
+
+// IsLocal returns true if the volume is using the local driver
+func (v DockerVolume) IsLocal() bool {
+	return v.Driver == "local"
+}
+
+// DockerVolumeSize represents size information from docker system df
+type DockerVolumeSize struct {
+	Name     string `json:"Name"`
+	Size     int64  `json:"Size"`
+	RefCount int    `json:"RefCount"`
+}

--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -955,6 +955,13 @@ func (m *Model) BackFromInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Check if we were inspecting a volume
+	if m.inspectVolumeID != "" {
+		m.currentView = VolumeListView
+		m.inspectVolumeID = ""
+		return m, nil
+	}
+
 	// Check where we came from based on the container ID
 	for _, container := range m.dockerContainers {
 		if container.ID == m.inspectContainerID {

--- a/internal/ui/keyhandler_volume.go
+++ b/internal/ui/keyhandler_volume.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+)
+
+// Volume navigation handlers
+func (m *Model) SelectUpVolume(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectedDockerVolume > 0 {
+		m.selectedDockerVolume--
+	}
+	return m, nil
+}
+
+func (m *Model) SelectDownVolume(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectedDockerVolume < len(m.dockerVolumes)-1 {
+		m.selectedDockerVolume++
+	}
+	return m, nil
+}
+
+// View change handlers
+func (m *Model) ShowVolumeList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.currentView = VolumeListView
+	m.loading = true
+	m.selectedDockerVolume = 0
+	m.err = nil
+	return m, loadDockerVolumes(m.dockerClient)
+}
+
+func (m *Model) BackFromVolumeList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.currentView = ComposeProcessListView
+	m.err = nil
+	return m, loadProcesses(m.dockerClient, m.projectName, m.showAll)
+}
+
+// Action handlers
+func (m *Model) ShowVolumeInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.dockerVolumes) == 0 || m.selectedDockerVolume >= len(m.dockerVolumes) {
+		return m, nil
+	}
+
+	volume := m.dockerVolumes[m.selectedDockerVolume]
+	m.loading = true
+	m.err = nil
+	m.inspectVolumeID = volume.Name
+	m.currentView = InspectView
+
+	return m, inspectVolume(m.dockerClient, volume.Name)
+}
+
+func (m *Model) RefreshVolumeList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.loading = true
+	m.err = nil
+	return m, loadDockerVolumes(m.dockerClient)
+}
+
+func (m *Model) DeleteVolume(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.dockerVolumes) == 0 || m.selectedDockerVolume >= len(m.dockerVolumes) {
+		return m, nil
+	}
+
+	volume := m.dockerVolumes[m.selectedDockerVolume]
+	m.loading = true
+	m.err = nil
+
+	return m, removeVolume(m.dockerClient, volume.Name, false)
+}
+
+func (m *Model) ForceDeleteVolume(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.dockerVolumes) == 0 || m.selectedDockerVolume >= len(m.dockerVolumes) {
+		return m, nil
+	}
+
+	volume := m.dockerVolumes[m.selectedDockerVolume]
+	m.loading = true
+	m.err = nil
+
+	return m, removeVolume(m.dockerClient, volume.Name, true)
+}
+
+// Command functions
+func inspectVolume(dockerClient *docker.Client, volumeID string) tea.Cmd {
+	return func() tea.Msg {
+		output, err := dockerClient.InspectVolume(volumeID)
+		if err != nil {
+			return errorMsg{err: err}
+		}
+		return inspectLoadedMsg{content: output}
+	}
+}
+
+func removeVolume(dockerClient *docker.Client, volumeName string, force bool) tea.Cmd {
+	return func() tea.Msg {
+		err := dockerClient.RemoveVolume(volumeName, force)
+		return serviceActionCompleteMsg{err: err}
+	}
+}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -15,6 +15,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"2"}, "project list", m.ShowProjectList},
 		{[]string{"3"}, "docker images", m.ShowImageList},
 		{[]string{"4"}, "docker networks", m.ShowNetworkList},
+		{[]string{"5"}, "docker volumes", m.ShowVolumeList},
 		{[]string{"f"}, "browse files", m.ShowFileBrowser},
 		{[]string{"!"}, "exec /bin/sh", m.ExecuteShell},
 		{[]string{"I"}, "inspect", m.ShowInspect},
@@ -156,6 +157,23 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"?"}, "help", m.ShowHelp},
 	}
 	m.networkListViewKeymap = m.createKeymap(m.networkListViewHandlers)
+
+	// Volume List View
+	m.volumeListViewHandlers = []KeyConfig{
+		{[]string{"up", "k"}, "move up", m.SelectUpVolume},
+		{[]string{"down", "j"}, "move down", m.SelectDownVolume},
+		{[]string{"enter"}, "inspect", m.ShowVolumeInspect},
+		{[]string{"r"}, "refresh", m.RefreshVolumeList},
+		{[]string{"D"}, "remove", m.DeleteVolume},
+		{[]string{"F"}, "force remove", m.ForceDeleteVolume},
+		{[]string{"1"}, "docker ps", m.ShowDockerContainerList},
+		{[]string{"2"}, "project list", m.ShowProjectList},
+		{[]string{"3"}, "docker images", m.ShowImageList},
+		{[]string{"4"}, "docker networks", m.ShowNetworkList},
+		{[]string{"esc", "q"}, "back", m.BackFromVolumeList},
+		{[]string{"?"}, "help", m.ShowHelp},
+	}
+	m.volumeListViewKeymap = m.createKeymap(m.volumeListViewHandlers)
 
 	// File Browser View
 	m.fileBrowserHandlers = []KeyConfig{

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -42,6 +42,7 @@ const (
 	DockerContainerListView
 	ImageListView
 	NetworkListView
+	VolumeListView
 	FileBrowserView
 	FileContentView
 	InspectView
@@ -84,6 +85,10 @@ type Model struct {
 	dockerNetworks        []models.DockerNetwork
 	selectedDockerNetwork int
 
+	// Docker volumes state
+	dockerVolumes        []models.DockerVolume
+	selectedDockerVolume int
+
 	// File browser state
 	containerFiles        []models.ContainerFile
 	selectedFile          int
@@ -103,6 +108,7 @@ type Model struct {
 	inspectContainerID string
 	inspectImageID     string
 	inspectNetworkID   string
+	inspectVolumeID    string
 
 	// Log view state
 	logs          []string
@@ -165,6 +171,8 @@ type Model struct {
 	imageListViewHandlers   []KeyConfig
 	networkListViewKeymap   map[string]KeyHandler
 	networkListViewHandlers []KeyConfig
+	volumeListViewKeymap    map[string]KeyHandler
+	volumeListViewHandlers  []KeyConfig
 	fileBrowserKeymap       map[string]KeyHandler
 	fileBrowserHandlers     []KeyConfig
 	fileContentKeymap       map[string]KeyHandler
@@ -409,6 +417,11 @@ type dockerImagesLoadedMsg struct {
 type dockerNetworksLoadedMsg struct {
 	networks []models.DockerNetwork
 	err      error
+}
+
+type dockerVolumesLoadedMsg struct {
+	volumes []models.DockerVolume
+	err     error
 }
 
 type containerFilesLoadedMsg struct {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -208,6 +208,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case dockerVolumesLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.dockerVolumes = msg.volumes
+		m.err = nil
+		if len(m.dockerVolumes) > 0 && m.selectedDockerVolume >= len(m.dockerVolumes) {
+			m.selectedDockerVolume = 0
+		}
+		return m, nil
+
 	case containerFilesLoadedMsg:
 		m.loading = false
 		if msg.err != nil {
@@ -354,6 +367,8 @@ func (m *Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleImageListKeys(msg)
 	case NetworkListView:
 		return m.handleNetworkListKeys(msg)
+	case VolumeListView:
+		return m.handleVolumeListKeys(msg)
 	case FileBrowserView:
 		return m.handleFileBrowserKeys(msg)
 	case FileContentView:
@@ -620,6 +635,8 @@ func (m *Model) refreshCurrentView() tea.Cmd {
 		return loadDockerImages(m.dockerClient, m.showAll)
 	case NetworkListView:
 		return loadDockerNetworks(m.dockerClient)
+	case VolumeListView:
+		return loadDockerVolumes(m.dockerClient)
 	case ProjectListView:
 		return loadProjects(m.dockerClient)
 	case DindComposeProcessListView:
@@ -676,6 +693,14 @@ func (m *Model) handleImageListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) handleNetworkListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	handler, ok := m.networkListViewKeymap[msg.String()]
+	if ok {
+		return handler(msg)
+	}
+	return m, nil
+}
+
+func (m *Model) handleVolumeListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	handler, ok := m.volumeListViewKeymap[msg.String()]
 	if ok {
 		return handler(msg)
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -225,6 +225,8 @@ func (m *Model) viewTitle() string {
 		return "Docker Images"
 	case NetworkListView:
 		return "Docker Networks"
+	case VolumeListView:
+		return "Docker Volumes"
 	case FileBrowserView:
 		return fmt.Sprintf("File Browser: %s [%s]", m.browsingContainerName, m.currentPath)
 	case FileContentView:
@@ -235,6 +237,8 @@ func (m *Model) viewTitle() string {
 			base = fmt.Sprintf("Image Inspect: %s", m.inspectImageID)
 		} else if m.inspectNetworkID != "" {
 			base = fmt.Sprintf("Network Inspect: %s", m.inspectNetworkID)
+		} else if m.inspectVolumeID != "" {
+			base = fmt.Sprintf("Volume Inspect: %s", m.inspectVolumeID)
 		} else {
 			base = fmt.Sprintf("Container Inspect: %s", m.inspectContainerID)
 		}
@@ -295,6 +299,8 @@ func (m *Model) viewBody(availableHeight int) string {
 		return m.renderImageList(availableHeight)
 	case NetworkListView:
 		return m.renderNetworkList(availableHeight)
+	case VolumeListView:
+		return m.renderVolumeList()
 	case FileBrowserView:
 		return m.renderFileBrowser(availableHeight)
 	case FileContentView:

--- a/internal/ui/view_help.go
+++ b/internal/ui/view_help.go
@@ -42,6 +42,9 @@ func (m *Model) renderHelpView(availableHeight int) string {
 	case NetworkListView:
 		configs = m.networkListViewHandlers
 		viewName = "Docker Networks"
+	case VolumeListView:
+		configs = m.volumeListViewHandlers
+		viewName = "Docker Volumes"
 	case FileBrowserView:
 		configs = m.fileBrowserHandlers
 		viewName = "File Browser"

--- a/internal/ui/view_volume_list.go
+++ b/internal/ui/view_volume_list.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+)
+
+func (m Model) renderVolumeList() string {
+	s := strings.Builder{}
+	s.WriteString(titleStyle.Render("📦 Docker Volumes"))
+	s.WriteString("\n\n")
+
+	if m.loading {
+		s.WriteString("Loading volumes...")
+		return s.String()
+	}
+
+	if m.err != nil {
+		s.WriteString(errorStyle.Render(fmt.Sprintf("Error: %s", m.err.Error())))
+		return s.String()
+	}
+
+	if len(m.dockerVolumes) == 0 {
+		s.WriteString("No volumes found.\n")
+		s.WriteString(helpStyle.Render("\nPress 'q' to go back"))
+		return s.String()
+	}
+
+	// Create table columns
+	columns := []table.Column{
+		{Title: "Name", Width: 40},
+		{Title: "Driver", Width: 10},
+		{Title: "Scope", Width: 10},
+		{Title: "Size", Width: 12},
+		{Title: "Created", Width: 20},
+		{Title: "Ref Count", Width: 10},
+	}
+
+	// Create table rows
+	rows := make([]table.Row, len(m.dockerVolumes))
+	for i, volume := range m.dockerVolumes {
+		size := formatBytes(volume.Size)
+		if volume.Size == 0 {
+			size = "-"
+		}
+		
+		refCount := fmt.Sprintf("%d", volume.RefCount)
+		if volume.RefCount == 0 && volume.Size == 0 {
+			refCount = "-"
+		}
+
+		created := volume.CreatedAt.Format("2006-01-02 15:04:05")
+		if volume.CreatedAt.IsZero() {
+			created = "-"
+		}
+
+		rows[i] = table.Row{
+			volume.Name,
+			volume.Driver,
+			volume.Scope,
+			size,
+			created,
+			refCount,
+		}
+	}
+
+	// Create table
+	t := table.New(
+		table.WithColumns(columns),
+		table.WithRows(rows),
+		table.WithFocused(true),
+		table.WithHeight(min(len(rows), m.height-8)),
+	)
+
+	tableStyle := table.DefaultStyles()
+	tableStyle.Header = tableStyle.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		BorderBottom(true).
+		Bold(false)
+	tableStyle.Selected = tableStyle.Selected.
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("57")).
+		Bold(false)
+
+	t.SetStyles(tableStyle)
+	t.Focus()
+
+	// Move to selected row
+	for i := 0; i < m.selectedDockerVolume; i++ {
+		t.MoveDown(1)
+	}
+
+	s.WriteString(t.View())
+	s.WriteString("\n")
+
+	return s.String()
+}
+
+// formatBytes formats bytes into human-readable format
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func loadDockerVolumes(dockerClient *docker.Client) tea.Cmd {
+	return func() tea.Msg {
+		volumes, err := dockerClient.ListVolumes()
+		return dockerVolumesLoadedMsg{volumes: volumes, err: err}
+	}
+}


### PR DESCRIPTION
## Summary
Add comprehensive Docker volume management functionality to dcv, allowing users to list, inspect, and remove Docker volumes.

## Features Added
- **Volume List View**: Shows all Docker volumes with detailed information
  - Volume name
  - Driver type
  - Scope
  - Size (from docker system df)
  - Creation date
  - Reference count (number of containers using the volume)
  
- **Volume Management**:
  - Inspect volumes to see full configuration
  - Remove unused volumes
  - Force remove volumes (even if in use)
  - Navigate between volumes with vim-style keybindings
  
- **Navigation**: Access volume list with key `5` from main views

## Technical Implementation
- Created `DockerVolume` model with size and reference count fields
- Implemented `ListVolumes`, `InspectVolume`, and `RemoveVolume` in docker client
- Added `getVolumeSizes` to fetch volume size data from `docker system df`
- Created volume list view using bubble tea table component
- Added volume-specific keybindings and handlers
- Integrated volume view into the main navigation flow

## Testing
- All existing tests pass
- Volume functionality tested manually with Docker volumes

## Documentation
- Updated CLAUDE.md with volume list view documentation
- Updated README.md to mention volume management features
- Added help text for volume-specific keybindings

🤖 Generated with [Claude Code](https://claude.ai/code)