### PR TITLE
refactor: implement split view models architecture

### DIFF
--- a/internal/ui/root_screen.go
+++ b/internal/ui/root_screen.go
@@ -1,0 +1,157 @@
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+	"github.com/tokuhirom/dcv/internal/ui/views"
+)
+
+// RootScreen is the main model that manages view switching
+type RootScreen struct {
+	// Current view model
+	model tea.Model
+
+	// Shared dependencies
+	dockerClient *docker.Client
+
+	// Global state
+	width  int
+	height int
+
+	// Command mode state (shared across views)
+	commandMode bool
+	commandText string
+}
+
+// NewRootScreen creates a new root screen
+func NewRootScreen(dockerClient *docker.Client, initialView ViewType, projectName string) *RootScreen {
+	root := &RootScreen{
+		dockerClient: dockerClient,
+	}
+
+	// Create initial view
+	var initialModel tea.Model
+	switch initialView {
+	case ComposeProcessListView:
+		composeView := views.NewComposeListView(dockerClient, projectName)
+		composeView.SetRootScreen(root)
+		initialModel = composeView
+	case DockerContainerListView:
+		dockerView := views.NewDockerListView(dockerClient)
+		dockerView.SetRootScreen(root)
+		initialModel = dockerView
+	case ProjectListView:
+		projectView := views.NewProjectListView(dockerClient)
+		projectView.SetRootScreen(root)
+		initialModel = projectView
+	default:
+		dockerView := views.NewDockerListView(dockerClient)
+		dockerView.SetRootScreen(root)
+		initialModel = dockerView
+	}
+
+	root.model = initialModel
+	return root
+}
+
+// Init initializes the root screen
+func (r *RootScreen) Init() tea.Cmd {
+	return r.model.Init()
+}
+
+// Update handles messages for the root screen
+func (r *RootScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		r.width = msg.Width
+		r.height = msg.Height
+		// Pass size to current model
+		if sizable, ok := r.model.(interface{ SetSize(int, int) }); ok {
+			sizable.SetSize(r.width, r.height)
+		}
+
+	case tea.KeyMsg:
+		// Handle global keys
+		switch msg.String() {
+		case ":":
+			if !r.commandMode {
+				r.commandMode = true
+				r.commandText = ""
+				return r, nil
+			}
+		case "esc":
+			if r.commandMode {
+				r.commandMode = false
+				r.commandText = ""
+				return r, nil
+			}
+		}
+
+		// If in command mode, handle command input
+		if r.commandMode {
+			return r.handleCommandMode(msg)
+		}
+	}
+
+	// Delegate to current view
+	updatedModel, cmd := r.model.Update(msg)
+	r.model = updatedModel
+	return r, cmd
+}
+
+// View renders the current view
+func (r *RootScreen) View() string {
+	view := r.model.View()
+
+	// TODO: Add command line rendering if in command mode
+
+	return view
+}
+
+// SwitchScreen switches to a new screen model
+func (r *RootScreen) SwitchScreen(model tea.Model) (tea.Model, tea.Cmd) {
+	r.model = model
+
+	// Set size on new model if it supports it
+	if sizable, ok := r.model.(interface{ SetSize(int, int) }); ok {
+		sizable.SetSize(r.width, r.height)
+	}
+
+	// Initialize the new screen
+	return r, r.model.Init()
+}
+
+func (r *RootScreen) handleCommandMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEnter:
+		// Execute command
+		r.commandMode = false
+		cmd := r.commandText
+		r.commandText = ""
+		return r.executeCommand(cmd)
+
+	case tea.KeyBackspace:
+		if len(r.commandText) > 0 {
+			r.commandText = r.commandText[:len(r.commandText)-1]
+		}
+
+	case tea.KeyRunes:
+		r.commandText += string(msg.Runes)
+	}
+
+	return r, nil
+}
+
+func (r *RootScreen) executeCommand(cmd string) (tea.Model, tea.Cmd) {
+	// Handle commands
+	switch cmd {
+	case "q", "quit":
+		return r, tea.Quit
+	case "q!", "quit!":
+		return r, tea.Quit
+		// TODO: Add more commands
+	}
+
+	return r, nil
+}

--- a/internal/ui/views/compose_list.go
+++ b/internal/ui/views/compose_list.go
@@ -1,0 +1,256 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+	"github.com/tokuhirom/dcv/internal/models"
+)
+
+// ComposeListView represents the Docker Compose process list view
+type ComposeListView struct {
+	// View state
+	width             int
+	height            int
+	selectedContainer int
+	containers        []models.ComposeContainer
+	projectName       string
+	showAll           bool
+
+	// Loading/error state
+	loading bool
+	err     error
+
+	// Dependencies
+	dockerClient *docker.Client
+	rootScreen   tea.Model // Reference to root for switching views
+}
+
+// NewComposeListView creates a new compose list view
+func NewComposeListView(dockerClient *docker.Client, projectName string) *ComposeListView {
+	return &ComposeListView{
+		dockerClient: dockerClient,
+		projectName:  projectName,
+		showAll:      false,
+	}
+}
+
+// SetRootScreen sets the root screen reference
+func (v *ComposeListView) SetRootScreen(root tea.Model) {
+	v.rootScreen = root
+}
+
+// SetSize updates the view dimensions
+func (v *ComposeListView) SetSize(width, height int) {
+	v.width = width
+	v.height = height
+}
+
+// Init initializes the view
+func (v *ComposeListView) Init() tea.Cmd {
+	v.loading = true
+	return loadProcesses(v.dockerClient, v.projectName, v.showAll)
+}
+
+// Update handles messages for this view
+func (v *ComposeListView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+		return v, nil
+
+	case tea.KeyMsg:
+		return v.handleKeyPress(msg)
+
+	case processesLoadedMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.err = msg.err
+			return v, nil
+		}
+		v.containers = msg.processes
+		v.err = nil
+		if len(v.containers) > 0 && v.selectedContainer >= len(v.containers) {
+			v.selectedContainer = 0
+		}
+		return v, nil
+
+	case RefreshMsg:
+		v.loading = true
+		v.err = nil
+		return v, loadProcesses(v.dockerClient, v.projectName, v.showAll)
+	}
+
+	return v, nil
+}
+
+// View renders the compose list view
+func (v *ComposeListView) View() string {
+	if v.loading {
+		return renderLoadingView(v.width, v.height, "Loading compose containers...")
+	}
+
+	if v.err != nil {
+		return renderErrorView(v.width, v.height, v.err)
+	}
+
+	return v.renderComposeList()
+}
+
+func (v *ComposeListView) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if v.selectedContainer > 0 {
+			v.selectedContainer--
+		}
+		return v, nil
+
+	case "down", "j":
+		if v.selectedContainer < len(v.containers)-1 {
+			v.selectedContainer++
+		}
+		return v, nil
+
+	case "enter":
+		// Switch to log view
+		if v.selectedContainer < len(v.containers) && v.rootScreen != nil {
+			container := v.containers[v.selectedContainer]
+			// Use the root screen's SwitchScreen method
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				logView := NewLogView(v.dockerClient, container.ID, container.Name, false)
+				logView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(logView)
+			}
+		}
+		return v, nil
+
+	case "r":
+		// Send refresh message
+		return v, func() tea.Msg { return RefreshMsg{} }
+
+	case "a":
+		// Toggle show all
+		v.showAll = !v.showAll
+		v.loading = true
+		return v, loadProcesses(v.dockerClient, v.projectName, v.showAll)
+
+	case "?":
+		// Show help
+		if v.rootScreen != nil {
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				helpView := NewHelpView("Docker Compose", v)
+				helpView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(helpView)
+			}
+		}
+		return v, nil
+
+	case "q":
+		return v, tea.Quit
+	}
+
+	return v, nil
+}
+
+func (v *ComposeListView) renderComposeList() string {
+	var s strings.Builder
+
+	// Header
+	header := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("7")).
+		Background(lipgloss.Color("4")).
+		Width(v.width).
+		Padding(0, 1).
+		Render(fmt.Sprintf("Docker Compose - %s", v.projectName))
+	s.WriteString(header + "\n")
+
+	// Container list
+	if len(v.containers) == 0 {
+		s.WriteString("\nNo containers found.\n")
+	} else {
+		for i, container := range v.containers {
+			selected := i == v.selectedContainer
+			line := formatContainerLine(container, v.width, selected)
+			s.WriteString(line + "\n")
+		}
+	}
+
+	// Footer
+	footer := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Width(v.width).
+		Align(lipgloss.Center).
+		Render("↑/↓: Navigate • Enter: Logs • r: Refresh • a: Toggle All • q: Quit")
+
+	// Pad to fill screen
+	content := s.String()
+	lines := strings.Split(content, "\n")
+	for len(lines) < v.height-2 {
+		lines = append(lines, "")
+	}
+
+	return strings.Join(lines, "\n") + "\n" + footer
+}
+
+// Helper functions
+func formatContainerLine(container models.ComposeContainer, width int, selected bool) string {
+	status := container.State
+	if container.Health != "" {
+		status = fmt.Sprintf("%s (%s)", status, container.Health)
+	}
+
+	line := fmt.Sprintf("%-30s %-15s %s", container.Name, container.Service, status)
+	if len(line) > width-3 {
+		line = line[:width-3]
+	}
+
+	style := lipgloss.NewStyle()
+	if selected {
+		style = style.Background(lipgloss.Color("240"))
+	}
+
+	return style.Render(line)
+}
+
+// Messages
+type processesLoadedMsg struct {
+	processes []models.ComposeContainer
+	err       error
+}
+
+// Commands
+func loadProcesses(client *docker.Client, projectName string, showAll bool) tea.Cmd {
+	return func() tea.Msg {
+		processes, err := client.Compose(projectName).ListContainers(showAll)
+		return processesLoadedMsg{processes: processes, err: err}
+	}
+}
+
+// Common view helpers
+func renderLoadingView(width, height int, message string) string {
+	return lipgloss.Place(width, height,
+		lipgloss.Center, lipgloss.Center,
+		lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			Render(message),
+	)
+}
+
+func renderErrorView(width, height int, err error) string {
+	return lipgloss.Place(width, height,
+		lipgloss.Center, lipgloss.Center,
+		lipgloss.NewStyle().
+			Foreground(lipgloss.Color("1")).
+			Render(fmt.Sprintf("Error: %v", err)),
+	)
+}

--- a/internal/ui/views/docker_list.go
+++ b/internal/ui/views/docker_list.go
@@ -1,0 +1,280 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+	"github.com/tokuhirom/dcv/internal/models"
+)
+
+// DockerListView represents the Docker container list view
+type DockerListView struct {
+	// View state
+	width             int
+	height            int
+	selectedContainer int
+	containers        []models.DockerContainer
+	showAll           bool
+
+	// Loading/error state
+	loading bool
+	err     error
+
+	// Dependencies
+	dockerClient *docker.Client
+	rootScreen   tea.Model
+}
+
+// NewDockerListView creates a new Docker container list view
+func NewDockerListView(dockerClient *docker.Client) *DockerListView {
+	return &DockerListView{
+		dockerClient: dockerClient,
+		showAll:      false,
+	}
+}
+
+// SetRootScreen sets the root screen reference
+func (v *DockerListView) SetRootScreen(root tea.Model) {
+	v.rootScreen = root
+}
+
+// Init initializes the view
+func (v *DockerListView) Init() tea.Cmd {
+	v.loading = true
+	return loadDockerContainers(v.dockerClient, v.showAll)
+}
+
+// Update handles messages for this view
+func (v *DockerListView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+		return v, nil
+
+	case tea.KeyMsg:
+		return v.handleKeyPress(msg)
+
+	case dockerContainersLoadedMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.err = msg.err
+			return v, nil
+		}
+		v.containers = msg.containers
+		v.err = nil
+		if len(v.containers) > 0 && v.selectedContainer >= len(v.containers) {
+			v.selectedContainer = 0
+		}
+		return v, nil
+
+	case RefreshMsg:
+		v.loading = true
+		v.err = nil
+		return v, loadDockerContainers(v.dockerClient, v.showAll)
+	}
+
+	return v, nil
+}
+
+// View renders the Docker container list
+func (v *DockerListView) View() string {
+	if v.loading {
+		return renderLoadingView(v.width, v.height, "Loading Docker containers...")
+	}
+
+	if v.err != nil {
+		return renderErrorView(v.width, v.height, v.err)
+	}
+
+	return v.renderDockerList()
+}
+
+func (v *DockerListView) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if v.selectedContainer > 0 {
+			v.selectedContainer--
+		}
+		return v, nil
+
+	case "down", "j":
+		if v.selectedContainer < len(v.containers)-1 {
+			v.selectedContainer++
+		}
+		return v, nil
+
+	case "enter":
+		// Switch to log view
+		if v.selectedContainer < len(v.containers) && v.rootScreen != nil {
+			container := v.containers[v.selectedContainer]
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				// Extract container name
+				name := strings.TrimPrefix(container.Names, "/")
+				logView := NewLogView(v.dockerClient, container.ID, name, false)
+				logView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(logView)
+			}
+		}
+		return v, nil
+
+	case "r":
+		// Send refresh message
+		return v, func() tea.Msg { return RefreshMsg{} }
+
+	case "a":
+		// Toggle show all
+		v.showAll = !v.showAll
+		v.loading = true
+		return v, loadDockerContainers(v.dockerClient, v.showAll)
+
+	case "2":
+		// Switch to project list
+		if v.rootScreen != nil {
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				projectView := NewProjectListView(v.dockerClient)
+				projectView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(projectView)
+			}
+		}
+		return v, nil
+
+	case "3":
+		// Switch to image list
+		if v.rootScreen != nil {
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				imageView := NewImageListView(v.dockerClient)
+				imageView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(imageView)
+			}
+		}
+		return v, nil
+
+	case "q":
+		return v, tea.Quit
+	}
+
+	return v, nil
+}
+
+func (v *DockerListView) renderDockerList() string {
+	var s strings.Builder
+
+	// Header
+	header := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("7")).
+		Background(lipgloss.Color("4")).
+		Width(v.width).
+		Padding(0, 1).
+		Render("Docker Containers")
+	s.WriteString(header + "\n")
+
+	// Container list
+	if len(v.containers) == 0 {
+		s.WriteString("\nNo containers found.\n")
+	} else {
+		// Column headers
+		headers := fmt.Sprintf("%-15s %-30s %-20s %-15s %s",
+			"CONTAINER ID", "IMAGE", "COMMAND", "STATUS", "NAMES")
+		s.WriteString(lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240")).
+			Bold(true).
+			Render(headers) + "\n")
+
+		for i, container := range v.containers {
+			selected := i == v.selectedContainer
+			line := formatDockerContainerLine(container, v.width, selected)
+			s.WriteString(line + "\n")
+		}
+	}
+
+	// Footer
+	footer := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Width(v.width).
+		Align(lipgloss.Center).
+		Render("↑/↓: Navigate • Enter: Logs • r: Refresh • a: Toggle All • 2: Projects • 3: Images • q: Quit")
+
+	// Pad to fill screen
+	content := s.String()
+	lines := strings.Split(content, "\n")
+	for len(lines) < v.height-2 {
+		lines = append(lines, "")
+	}
+
+	return strings.Join(lines, "\n") + "\n" + footer
+}
+
+func formatDockerContainerLine(container models.DockerContainer, width int, selected bool) string {
+	// Truncate long fields
+	id := container.ID
+	if len(id) > 12 {
+		id = id[:12]
+	}
+
+	image := container.Image
+	if len(image) > 28 {
+		image = image[:28]
+	}
+
+	command := container.Command
+	if len(command) > 18 {
+		command = command[:18]
+	}
+
+	status := container.Status
+	if len(status) > 13 {
+		status = status[:13]
+	}
+
+	names := container.Names
+	if len(names) > 20 {
+		names = names[:20]
+	}
+
+	line := fmt.Sprintf("%-15s %-30s %-20s %-15s %s",
+		id, image, command, status, names)
+
+	if len(line) > width-3 {
+		line = line[:width-3]
+	}
+
+	style := lipgloss.NewStyle()
+	if selected {
+		style = style.Background(lipgloss.Color("240"))
+	}
+
+	// Color based on state
+	if strings.Contains(container.State, "running") {
+		style = style.Foreground(lipgloss.Color("2")) // Green
+	} else if strings.Contains(container.State, "exited") {
+		style = style.Foreground(lipgloss.Color("240")) // Gray
+	}
+
+	return style.Render(line)
+}
+
+// Messages
+type dockerContainersLoadedMsg struct {
+	containers []models.DockerContainer
+	err        error
+}
+
+// Commands
+func loadDockerContainers(client *docker.Client, showAll bool) tea.Cmd {
+	return func() tea.Msg {
+		containers, err := client.ListAllContainers(showAll)
+		return dockerContainersLoadedMsg{containers: containers, err: err}
+	}
+}

--- a/internal/ui/views/help_view.go
+++ b/internal/ui/views/help_view.go
@@ -1,0 +1,203 @@
+package views
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// HelpView represents the help screen
+type HelpView struct {
+	// View state
+	width      int
+	height     int
+	scrollY    int
+	helpText   []string
+	sourceView string // Remember which view we came from
+
+	// Dependencies
+	rootScreen   tea.Model
+	previousView tea.Model // Store the view to return to
+}
+
+// NewHelpView creates a new help view
+func NewHelpView(sourceView string, previousView tea.Model) *HelpView {
+	return &HelpView{
+		sourceView:   sourceView,
+		previousView: previousView,
+		helpText:     getHelpText(sourceView),
+	}
+}
+
+// SetRootScreen sets the root screen reference
+func (v *HelpView) SetRootScreen(root tea.Model) {
+	v.rootScreen = root
+}
+
+// Init initializes the view
+func (v *HelpView) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles messages for this view
+func (v *HelpView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+		return v, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k":
+			if v.scrollY > 0 {
+				v.scrollY--
+			}
+			return v, nil
+
+		case "down", "j":
+			maxScroll := len(v.helpText) - (v.height - 4)
+			if v.scrollY < maxScroll && maxScroll > 0 {
+				v.scrollY++
+			}
+			return v, nil
+
+		case "esc", "q", "?":
+			// Go back to previous view
+			if v.rootScreen != nil && v.previousView != nil {
+				if switcher, ok := v.rootScreen.(interface {
+					SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+				}); ok {
+					return switcher.SwitchScreen(v.previousView)
+				}
+			}
+			return v, nil
+		}
+	}
+
+	return v, nil
+}
+
+// View renders the help screen
+func (v *HelpView) View() string {
+	var s strings.Builder
+
+	// Header
+	header := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("7")).
+		Background(lipgloss.Color("4")).
+		Width(v.width).
+		Padding(0, 1).
+		Render("Help - " + v.sourceView)
+	s.WriteString(header + "\n\n")
+
+	// Calculate visible lines
+	visibleHeight := v.height - 4
+	start := v.scrollY
+	end := start + visibleHeight
+	if end > len(v.helpText) {
+		end = len(v.helpText)
+	}
+
+	// Render help text
+	for i := start; i < end; i++ {
+		if i < len(v.helpText) {
+			s.WriteString(v.helpText[i] + "\n")
+		}
+	}
+
+	// Pad to fill screen
+	lines := strings.Split(s.String(), "\n")
+	for len(lines) < v.height-1 {
+		lines = append(lines, "")
+	}
+
+	// Footer
+	footer := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Width(v.width).
+		Align(lipgloss.Center).
+		Render("↑/↓: Scroll • ESC/q/?: Close Help")
+
+	return strings.Join(lines[:v.height-1], "\n") + "\n" + footer
+}
+
+func getHelpText(viewName string) []string {
+	baseHelp := []string{
+		"NAVIGATION KEYS",
+		"===============",
+		"↑/k     Move up",
+		"↓/j     Move down",
+		"Enter   Select/Open",
+		"ESC/q   Go back/Quit",
+		"",
+		"VIEW SWITCHING",
+		"==============",
+		"1       Docker containers",
+		"2       Docker Compose projects",
+		"3       Docker images",
+		"4       Docker networks",
+		"5       Docker volumes",
+		"",
+		"COMMON ACTIONS",
+		"==============",
+		"r       Refresh current view",
+		"?       Show this help",
+		":       Enter command mode",
+		"",
+	}
+
+	switch viewName {
+	case "Docker Containers":
+		return append(baseHelp, []string{
+			"DOCKER CONTAINER ACTIONS",
+			"========================",
+			"a       Toggle show all (including stopped)",
+			"f       Browse container files",
+			"!       Execute shell in container",
+			"I       Inspect container",
+			"K       Kill container",
+			"S       Stop container",
+			"U       Start container",
+			"R       Restart container",
+			"P       Pause/Unpause container",
+			"D       Delete stopped container",
+		}...)
+
+	case "Docker Compose":
+		return append(baseHelp, []string{
+			"DOCKER COMPOSE ACTIONS",
+			"======================",
+			"a       Toggle show all containers",
+			"d       View dind containers",
+			"f       Browse container files",
+			"!       Execute shell in container",
+			"I       Inspect container",
+			"t       Show process info (top)",
+			"s       Show container stats",
+			"K       Kill service",
+			"S       Stop service",
+			"U       Start service",
+			"R       Restart service",
+			"P       Pause/Unpause container",
+			"D       Delete stopped container",
+			"u       Deploy all services (up -d)",
+			"x       Stop and remove all (down)",
+		}...)
+
+	case "Docker Images":
+		return append(baseHelp, []string{
+			"DOCKER IMAGE ACTIONS",
+			"====================",
+			"a       Toggle show all images",
+			"I       Inspect image",
+			"D       Remove image",
+			"F       Force remove image",
+		}...)
+
+	default:
+		return baseHelp
+	}
+}

--- a/internal/ui/views/image_list.go
+++ b/internal/ui/views/image_list.go
@@ -1,0 +1,282 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+	"github.com/tokuhirom/dcv/internal/models"
+)
+
+// ImageListView represents the Docker image list view
+type ImageListView struct {
+	// View state
+	width         int
+	height        int
+	selectedImage int
+	images        []models.DockerImage
+	showAll       bool
+
+	// Loading/error state
+	loading bool
+	err     error
+
+	// Dependencies
+	dockerClient *docker.Client
+	rootScreen   tea.Model
+}
+
+// NewImageListView creates a new image list view
+func NewImageListView(dockerClient *docker.Client) *ImageListView {
+	return &ImageListView{
+		dockerClient: dockerClient,
+		showAll:      false,
+	}
+}
+
+// SetRootScreen sets the root screen reference
+func (v *ImageListView) SetRootScreen(root tea.Model) {
+	v.rootScreen = root
+}
+
+// Init initializes the view
+func (v *ImageListView) Init() tea.Cmd {
+	v.loading = true
+	return loadDockerImages(v.dockerClient, v.showAll)
+}
+
+// Update handles messages for this view
+func (v *ImageListView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+		return v, nil
+
+	case tea.KeyMsg:
+		return v.handleKeyPress(msg)
+
+	case dockerImagesLoadedMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.err = msg.err
+			return v, nil
+		}
+		v.images = msg.images
+		v.err = nil
+		if len(v.images) > 0 && v.selectedImage >= len(v.images) {
+			v.selectedImage = 0
+		}
+		return v, nil
+
+	case RefreshMsg:
+		v.loading = true
+		v.err = nil
+		return v, loadDockerImages(v.dockerClient, v.showAll)
+
+	case serviceActionCompleteMsg:
+		if msg.err != nil {
+			v.err = msg.err
+			return v, nil
+		}
+		// Refresh after deletion
+		v.loading = true
+		return v, loadDockerImages(v.dockerClient, v.showAll)
+	}
+
+	return v, nil
+}
+
+// View renders the image list
+func (v *ImageListView) View() string {
+	if v.loading {
+		return renderLoadingView(v.width, v.height, "Loading Docker images...")
+	}
+
+	if v.err != nil {
+		return renderErrorView(v.width, v.height, v.err)
+	}
+
+	return v.renderImageList()
+}
+
+func (v *ImageListView) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if v.selectedImage > 0 {
+			v.selectedImage--
+		}
+		return v, nil
+
+	case "down", "j":
+		if v.selectedImage < len(v.images)-1 {
+			v.selectedImage++
+		}
+		return v, nil
+
+	case "r":
+		// Send refresh message
+		return v, func() tea.Msg { return RefreshMsg{} }
+
+	case "a":
+		// Toggle show all
+		v.showAll = !v.showAll
+		v.loading = true
+		return v, loadDockerImages(v.dockerClient, v.showAll)
+
+	case "D":
+		// Delete image
+		if v.selectedImage < len(v.images) {
+			image := v.images[v.selectedImage]
+			return v, removeImage(v.dockerClient, image.ID, false)
+		}
+		return v, nil
+
+	case "F":
+		// Force delete image
+		if v.selectedImage < len(v.images) {
+			image := v.images[v.selectedImage]
+			return v, removeImage(v.dockerClient, image.ID, true)
+		}
+		return v, nil
+
+	case "1":
+		// Switch to Docker container list
+		if v.rootScreen != nil {
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				dockerView := NewDockerListView(v.dockerClient)
+				dockerView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(dockerView)
+			}
+		}
+		return v, nil
+
+	case "esc", "q":
+		// Go back to Docker container list
+		if v.rootScreen != nil {
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				dockerView := NewDockerListView(v.dockerClient)
+				dockerView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(dockerView)
+			}
+		}
+		return v, nil
+	}
+
+	return v, nil
+}
+
+func (v *ImageListView) renderImageList() string {
+	var s strings.Builder
+
+	// Header
+	header := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("7")).
+		Background(lipgloss.Color("4")).
+		Width(v.width).
+		Padding(0, 1).
+		Render("Docker Images")
+	s.WriteString(header + "\n")
+
+	// Image list
+	if len(v.images) == 0 {
+		s.WriteString("\nNo images found.\n")
+	} else {
+		// Column headers
+		headers := fmt.Sprintf("%-30s %-20s %-15s %-20s %s",
+			"REPOSITORY", "TAG", "IMAGE ID", "CREATED", "SIZE")
+		s.WriteString(lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240")).
+			Bold(true).
+			Render(headers) + "\n")
+
+		for i, image := range v.images {
+			selected := i == v.selectedImage
+			line := formatImageLine(image, v.width, selected)
+			s.WriteString(line + "\n")
+		}
+	}
+
+	// Footer
+	footer := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Width(v.width).
+		Align(lipgloss.Center).
+		Render("↑/↓: Navigate • r: Refresh • a: Toggle All • D: Delete • F: Force Delete • 1: Docker • ESC: Back")
+
+	// Pad to fill screen
+	content := s.String()
+	lines := strings.Split(content, "\n")
+	for len(lines) < v.height-2 {
+		lines = append(lines, "")
+	}
+
+	return strings.Join(lines, "\n") + "\n" + footer
+}
+
+func formatImageLine(image models.DockerImage, width int, selected bool) string {
+	// Truncate long fields
+	repo := image.Repository
+	if repo == "<none>" {
+		repo = image.ID
+		if len(repo) > 12 {
+			repo = repo[:12]
+		}
+	}
+	if len(repo) > 28 {
+		repo = repo[:28]
+	}
+
+	tag := image.Tag
+	if len(tag) > 18 {
+		tag = tag[:18]
+	}
+
+	id := image.ID
+	if len(id) > 12 {
+		id = id[:12]
+	}
+
+	line := fmt.Sprintf("%-30s %-20s %-15s %-20s %s",
+		repo, tag, id, image.CreatedSince, image.Size)
+
+	if len(line) > width-3 {
+		line = line[:width-3]
+	}
+
+	style := lipgloss.NewStyle()
+	if selected {
+		style = style.Background(lipgloss.Color("240"))
+	}
+
+	return style.Render(line)
+}
+
+// Messages
+type dockerImagesLoadedMsg struct {
+	images []models.DockerImage
+	err    error
+}
+
+// Commands
+func loadDockerImages(client *docker.Client, showAll bool) tea.Cmd {
+	return func() tea.Msg {
+		images, err := client.ListImages(showAll)
+		return dockerImagesLoadedMsg{images: images, err: err}
+	}
+}
+
+func removeImage(client *docker.Client, imageID string, force bool) tea.Cmd {
+	return func() tea.Msg {
+		err := client.RemoveImage(imageID, force)
+		return serviceActionCompleteMsg{err: err}
+	}
+}

--- a/internal/ui/views/log_view.go
+++ b/internal/ui/views/log_view.go
@@ -1,0 +1,258 @@
+package views
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+)
+
+// LogView represents the container log view
+type LogView struct {
+	// View state
+	width         int
+	height        int
+	logs          []string
+	scrollY       int
+	containerID   string
+	containerName string
+	isDind        bool
+
+	// Search state
+	searchMode bool
+	searchText string
+
+	// Dependencies
+	dockerClient *docker.Client
+	rootScreen   tea.Model
+}
+
+// NewLogView creates a new log view
+func NewLogView(dockerClient *docker.Client, containerID, containerName string, isDind bool) *LogView {
+	return &LogView{
+		dockerClient:  dockerClient,
+		containerID:   containerID,
+		containerName: containerName,
+		isDind:        isDind,
+		logs:          []string{},
+	}
+}
+
+// SetRootScreen sets the root screen reference
+func (v *LogView) SetRootScreen(root tea.Model) {
+	v.rootScreen = root
+}
+
+// Init initializes the log view
+func (v *LogView) Init() tea.Cmd {
+	// Start streaming logs
+	return streamLogs(v.dockerClient, v.containerID, v.isDind, "")
+}
+
+// Update handles messages for the log view
+func (v *LogView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+		return v, nil
+
+	case tea.KeyMsg:
+		if v.searchMode {
+			return v.handleSearchMode(msg)
+		}
+		return v.handleKeyPress(msg)
+
+	case logLineMsg:
+		v.logs = append(v.logs, msg.line)
+		// Keep only last 10000 lines
+		if len(v.logs) > 10000 {
+			v.logs = v.logs[len(v.logs)-10000:]
+		}
+		// Auto-scroll to bottom
+		maxScroll := len(v.logs) - (v.height - 4)
+		if maxScroll > 0 {
+			v.scrollY = maxScroll
+		}
+		return v, nil
+
+	case logLinesMsg:
+		v.logs = append(v.logs, msg.lines...)
+		if len(v.logs) > 10000 {
+			v.logs = v.logs[len(v.logs)-10000:]
+		}
+		maxScroll := len(v.logs) - (v.height - 4)
+		if maxScroll > 0 {
+			v.scrollY = maxScroll
+		}
+		// Continue polling
+		return v, tea.Tick(time.Millisecond*50, func(time.Time) tea.Msg {
+			return pollForLogs()()
+		})
+	}
+
+	return v, nil
+}
+
+// View renders the log view
+func (v *LogView) View() string {
+	var s strings.Builder
+
+	// Header
+	header := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("7")).
+		Background(lipgloss.Color("4")).
+		Width(v.width).
+		Padding(0, 1).
+		Render("Logs - " + v.containerName)
+	s.WriteString(header + "\n")
+
+	// Calculate visible logs
+	visibleHeight := v.height - 3 // Header + footer
+	start := v.scrollY
+	end := start + visibleHeight
+	if end > len(v.logs) {
+		end = len(v.logs)
+	}
+
+	// Render logs
+	if len(v.logs) == 0 {
+		s.WriteString("\nWaiting for logs...\n")
+	} else {
+		for i := start; i < end; i++ {
+			if i < len(v.logs) {
+				s.WriteString(v.logs[i] + "\n")
+			}
+		}
+	}
+
+	// Pad to fill screen
+	lines := strings.Split(s.String(), "\n")
+	for len(lines) < v.height-1 {
+		lines = append(lines, "")
+	}
+
+	// Footer
+	footer := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Width(v.width).
+		Align(lipgloss.Center).
+		Render("↑/↓: Scroll • /: Search • ESC: Back • q: Back")
+
+	return strings.Join(lines[:v.height-1], "\n") + "\n" + footer
+}
+
+func (v *LogView) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if v.scrollY > 0 {
+			v.scrollY--
+		}
+		return v, nil
+
+	case "down", "j":
+		maxScroll := len(v.logs) - (v.height - 4)
+		if v.scrollY < maxScroll && maxScroll > 0 {
+			v.scrollY++
+		}
+		return v, nil
+
+	case "G":
+		// Go to end
+		maxScroll := len(v.logs) - (v.height - 4)
+		if maxScroll > 0 {
+			v.scrollY = maxScroll
+		}
+		return v, nil
+
+	case "g":
+		// Go to start
+		v.scrollY = 0
+		return v, nil
+
+	case "/":
+		// Enter search mode
+		v.searchMode = true
+		v.searchText = ""
+		return v, nil
+
+	case "esc", "q":
+		// Go back to compose list
+		if v.rootScreen != nil {
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				// Stop log reader
+				stopLogReader()
+
+				// Switch back to compose list
+				composeView := NewComposeListView(v.dockerClient, "")
+				composeView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(composeView)
+			}
+		}
+		return v, nil
+	}
+
+	return v, nil
+}
+
+func (v *LogView) handleSearchMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		v.searchMode = false
+		v.searchText = ""
+		return v, nil
+
+	case tea.KeyEnter:
+		v.searchMode = false
+		// TODO: Implement search
+		return v, nil
+
+	case tea.KeyBackspace:
+		if len(v.searchText) > 0 {
+			v.searchText = v.searchText[:len(v.searchText)-1]
+		}
+		return v, nil
+
+	case tea.KeyRunes:
+		v.searchText += string(msg.Runes)
+		return v, nil
+	}
+
+	return v, nil
+}
+
+// Messages
+type logLineMsg struct {
+	line string
+}
+
+type logLinesMsg struct {
+	lines []string
+}
+
+type pollLogsContinueMsg struct{}
+
+// Commands
+func streamLogs(client *docker.Client, containerID string, isDind bool, hostContainer string) tea.Cmd {
+	// TODO: Implement actual log streaming
+	return func() tea.Msg {
+		return logLineMsg{line: "Starting container logs..."}
+	}
+}
+
+func pollForLogs() tea.Cmd {
+	// TODO: Implement actual log polling
+	return func() tea.Msg {
+		return pollLogsContinueMsg{}
+	}
+}
+
+func stopLogReader() {
+	// TODO: Implement stopping log reader
+}

--- a/internal/ui/views/messages.go
+++ b/internal/ui/views/messages.go
@@ -1,0 +1,9 @@
+package views
+
+// RefreshMsg signals that the current view should be refreshed
+type RefreshMsg struct{}
+
+// serviceActionCompleteMsg indicates a service action (like delete) completed
+type serviceActionCompleteMsg struct {
+	err error
+}

--- a/internal/ui/views/project_list.go
+++ b/internal/ui/views/project_list.go
@@ -1,0 +1,242 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+	"github.com/tokuhirom/dcv/internal/models"
+)
+
+// ProjectListView represents the Docker Compose project list view
+type ProjectListView struct {
+	// View state
+	width           int
+	height          int
+	selectedProject int
+	projects        []models.ComposeProject
+
+	// Loading/error state
+	loading bool
+	err     error
+
+	// Dependencies
+	dockerClient *docker.Client
+	rootScreen   tea.Model
+}
+
+// NewProjectListView creates a new project list view
+func NewProjectListView(dockerClient *docker.Client) *ProjectListView {
+	return &ProjectListView{
+		dockerClient: dockerClient,
+	}
+}
+
+// SetRootScreen sets the root screen reference
+func (v *ProjectListView) SetRootScreen(root tea.Model) {
+	v.rootScreen = root
+}
+
+// Init initializes the view
+func (v *ProjectListView) Init() tea.Cmd {
+	v.loading = true
+	return loadProjects(v.dockerClient)
+}
+
+// Update handles messages for this view
+func (v *ProjectListView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+		return v, nil
+
+	case tea.KeyMsg:
+		return v.handleKeyPress(msg)
+
+	case projectsLoadedMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.err = msg.err
+			return v, nil
+		}
+		v.projects = msg.projects
+		v.err = nil
+		if len(v.projects) > 0 && v.selectedProject >= len(v.projects) {
+			v.selectedProject = 0
+		}
+		return v, nil
+
+	case RefreshMsg:
+		v.loading = true
+		v.err = nil
+		return v, loadProjects(v.dockerClient)
+	}
+
+	return v, nil
+}
+
+// View renders the project list
+func (v *ProjectListView) View() string {
+	if v.loading {
+		return renderLoadingView(v.width, v.height, "Loading Docker Compose projects...")
+	}
+
+	if v.err != nil {
+		return renderErrorView(v.width, v.height, v.err)
+	}
+
+	return v.renderProjectList()
+}
+
+func (v *ProjectListView) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if v.selectedProject > 0 {
+			v.selectedProject--
+		}
+		return v, nil
+
+	case "down", "j":
+		if v.selectedProject < len(v.projects)-1 {
+			v.selectedProject++
+		}
+		return v, nil
+
+	case "enter":
+		// Switch to compose list view for selected project
+		if v.selectedProject < len(v.projects) && v.rootScreen != nil {
+			project := v.projects[v.selectedProject]
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				composeView := NewComposeListView(v.dockerClient, project.Name)
+				composeView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(composeView)
+			}
+		}
+		return v, nil
+
+	case "r":
+		// Send refresh message
+		return v, func() tea.Msg { return RefreshMsg{} }
+
+	case "1":
+		// Switch to Docker container list
+		if v.rootScreen != nil {
+			if switcher, ok := v.rootScreen.(interface {
+				SwitchScreen(tea.Model) (tea.Model, tea.Cmd)
+			}); ok {
+				dockerView := NewDockerListView(v.dockerClient)
+				dockerView.SetRootScreen(v.rootScreen)
+				return switcher.SwitchScreen(dockerView)
+			}
+		}
+		return v, nil
+
+	case "q":
+		return v, tea.Quit
+	}
+
+	return v, nil
+}
+
+func (v *ProjectListView) renderProjectList() string {
+	var s strings.Builder
+
+	// Header
+	header := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("7")).
+		Background(lipgloss.Color("4")).
+		Width(v.width).
+		Padding(0, 1).
+		Render("Docker Compose Projects")
+	s.WriteString(header + "\n")
+
+	// Project list
+	if len(v.projects) == 0 {
+		s.WriteString("\nNo Docker Compose projects found.\n")
+	} else {
+		// Column headers
+		headers := fmt.Sprintf("%-30s %-15s %s",
+			"NAME", "STATUS", "CONFIG FILES")
+		s.WriteString(lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240")).
+			Bold(true).
+			Render(headers) + "\n")
+
+		for i, project := range v.projects {
+			selected := i == v.selectedProject
+			line := formatProjectLine(project, v.width, selected)
+			s.WriteString(line + "\n")
+		}
+	}
+
+	// Footer
+	footer := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Width(v.width).
+		Align(lipgloss.Center).
+		Render("↑/↓: Navigate • Enter: View Project • r: Refresh • 1: Docker • q: Quit")
+
+	// Pad to fill screen
+	content := s.String()
+	lines := strings.Split(content, "\n")
+	for len(lines) < v.height-2 {
+		lines = append(lines, "")
+	}
+
+	return strings.Join(lines, "\n") + "\n" + footer
+}
+
+func formatProjectLine(project models.ComposeProject, width int, selected bool) string {
+	// Truncate long fields
+	name := project.Name
+	if len(name) > 28 {
+		name = name[:28]
+	}
+
+	configFiles := project.ConfigFiles
+	if len(configFiles) > 18 {
+		configFiles = configFiles[:18]
+	}
+
+	line := fmt.Sprintf("%-30s %-15s %s",
+		name, project.Status, configFiles)
+
+	if len(line) > width-3 {
+		line = line[:width-3]
+	}
+
+	style := lipgloss.NewStyle()
+	if selected {
+		style = style.Background(lipgloss.Color("240"))
+	}
+
+	// Color based on status
+	if strings.Contains(strings.ToLower(project.Status), "running") {
+		style = style.Foreground(lipgloss.Color("2")) // Green
+	} else {
+		style = style.Foreground(lipgloss.Color("240")) // Gray
+	}
+
+	return style.Render(line)
+}
+
+// Messages
+type projectsLoadedMsg struct {
+	projects []models.ComposeProject
+	err      error
+}
+
+// Commands
+func loadProjects(client *docker.Client) tea.Cmd {
+	return func() tea.Msg {
+		projects, err := client.ListComposeProjects()
+		return projectsLoadedMsg{projects: projects, err: err}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fujiwara/sloghandler"
 
 	"github.com/tokuhirom/dcv/internal/config"
+	"github.com/tokuhirom/dcv/internal/docker"
 	"github.com/tokuhirom/dcv/internal/ui"
 )
 
@@ -49,11 +50,14 @@ func main() {
 
 	slog.Info("Starting dcv", slog.String("initial_view", cfg.General.InitialView))
 
-	// Create the initial model with configured view
-	m := ui.NewModel(initialView, "")
+	// Create Docker client
+	dockerClient := docker.NewClient()
+
+	// Create the root screen with configured initial view
+	root := ui.NewRootScreen(dockerClient, initialView, "")
 
 	// Create the program
-	p := tea.NewProgram(&m, tea.WithAltScreen())
+	p := tea.NewProgram(root, tea.WithAltScreen())
 
 	// Run the program
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
## Summary
- Implementing split view models architecture based on the pattern described in https://shi.foo/weblog/multi-view-interfaces-in-bubble-tea
- Creating individual self-contained view models for better separation of concerns
- Each view manages its own state and implements the tea.Model interface

## Progress
- [x] Create RootScreen to manage view switching
- [x] Implement ComposeListView for Docker Compose containers
- [x] Implement DockerListView for Docker containers
- [x] Implement ProjectListView for Docker Compose projects
- [x] Implement ImageListView for Docker images
- [x] Implement HelpView for context-sensitive help
- [x] Update main.go to use RootScreen
- [ ] Migrate NetworkListView
- [ ] Migrate VolumeListView
- [ ] Migrate StatsView
- [ ] Migrate TopView
- [ ] Migrate FileBrowserView
- [ ] Migrate InspectView
- [ ] Migrate DindView
- [ ] Remove old Model struct
- [ ] Update tests

## Benefits
- Better separation of concerns - each view is isolated
- Easier to test individual views
- Cleaner code organization
- Follows established Bubble Tea patterns

🤖 Generated with [Claude Code](https://claude.ai/code)