### PR TITLE
refactor: add FileContentViewModel to view_file_content.go

### DIFF
--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -658,8 +658,7 @@ func (m *Model) OpenFileOrDirectory(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, loadContainerFiles(m.dockerClient, m.browsingContainerID, newPath)
 		} else {
 			// View file content
-			m.loading = true
-			return m, loadFileContent(m.dockerClient, m.browsingContainerID, newPath)
+			return m, m.fileContentViewModel.Load(m, m.browsingContainerID, newPath)
 		}
 	}
 	return m, nil
@@ -708,41 +707,23 @@ func (m *Model) CmdBack(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // File content handlers
 func (m *Model) ScrollFileUp(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.fileScrollY > 0 {
-		m.fileScrollY--
-	}
-	return m, nil
+	return m, m.fileContentViewModel.HandleScrollUp()
 }
 
 func (m *Model) ScrollFileDown(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	lines := strings.Split(m.fileContent, "\n")
-	maxScroll := len(lines) - (m.height - 5)
-	if m.fileScrollY < maxScroll && maxScroll > 0 {
-		m.fileScrollY++
-	}
-	return m, nil
+	return m, m.fileContentViewModel.HandleScrollDown(m.height)
 }
 
 func (m *Model) GoToFileEnd(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	lines := strings.Split(m.fileContent, "\n")
-	maxScroll := len(lines) - (m.height - 5)
-	if maxScroll > 0 {
-		m.fileScrollY = maxScroll
-	}
-	return m, nil
+	return m, m.fileContentViewModel.HandleGoToEnd(m.height)
 }
 
 func (m *Model) GoToFileStart(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.fileScrollY = 0
-	return m, nil
+	return m, m.fileContentViewModel.HandleGoToStart()
 }
 
 func (m *Model) BackFromFileContent(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = FileBrowserView
-	m.fileContent = ""
-	m.fileContentPath = ""
-	m.fileScrollY = 0
-	return m, nil
+	return m, m.fileContentViewModel.HandleBack(m)
 }
 
 func (m *Model) CmdShell(_ tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -110,6 +110,7 @@ type Model struct {
 	topViewModel                 TopViewModel
 	dindProcessListViewModel     DindProcessListViewModel
 	imageListViewModel           ImageListViewModel
+	fileContentViewModel         FileContentViewModel
 
 	// Docker images state
 	dockerImages        []models.DockerImage
@@ -130,11 +131,6 @@ type Model struct {
 	browsingContainerID   string
 	browsingContainerName string
 	pathHistory           []string
-
-	// File content view state
-	fileContent     string
-	fileContentPath string
-	fileScrollY     int
 
 	// Inspect view state
 	inspectContent     string

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -239,9 +239,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			return m, nil
 		}
-		m.fileContent = msg.content
-		m.fileContentPath = msg.path
-		m.fileScrollY = 0
+		m.fileContentViewModel.content = msg.content
+		m.fileContentViewModel.contentPath = msg.path
+		m.fileContentViewModel.scrollY = 0
 		m.err = nil
 		m.currentView = FileContentView
 		return m, nil

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -230,7 +230,7 @@ func (m *Model) viewTitle() string {
 	case FileBrowserView:
 		return fmt.Sprintf("File Browser: %s [%s]", m.browsingContainerName, m.currentPath)
 	case FileContentView:
-		return fmt.Sprintf("File: %s [%s]", filepath.Base(m.fileContentPath), m.browsingContainerName)
+		return fmt.Sprintf("File: %s [%s]", filepath.Base(m.fileContentViewModel.contentPath), m.browsingContainerName)
 	case InspectView:
 		base := ""
 		if m.inspectImageID != "" {
@@ -304,7 +304,7 @@ func (m *Model) viewBody(availableHeight int) string {
 	case FileBrowserView:
 		return m.renderFileBrowser(availableHeight)
 	case FileContentView:
-		return m.renderFileContent(availableHeight)
+		return m.fileContentViewModel.render(m, availableHeight)
 	case InspectView:
 		return m.renderInspectView(availableHeight)
 	case HelpView:


### PR DESCRIPTION
## Summary
- Introduces FileContentViewModel to manage file content view state and behavior
- Follows the established viewmodel refactoring pattern used across the codebase
- Improves code organization and maintainability

## Changes
- Add FileContentViewModel struct with content, contentPath, and scrollY fields
- Move render logic from Model to FileContentViewModel.render()
- Add handler methods:
  - Load(): Initialize view and load file content
  - HandleScrollUp/Down(): Handle vertical scrolling
  - HandleGoToStart/End(): Jump to beginning/end of file
  - HandleBack(): Return to file browser view
- Update keyhandlers to use new ViewModel methods
- Update fileContentLoadedMsg handler to populate ViewModel
- Remove old file content fields from Model struct

## Test plan
- [x] Code compiles without errors
- [x] All existing tests pass
- [x] Linter passes with no issues
- [ ] Manual testing of file content viewing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)