### PR TITLE
refactor: add HelpViewModel following established pattern

### DIFF
--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -876,30 +876,19 @@ func (m *Model) PrevInspectSearchResult(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // Help view handlers
 func (m *Model) ShowHelp(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.previousView = m.currentView
-	m.currentView = HelpView
-	m.helpScrollY = 0
-	return m, nil
+	return m, m.helpViewModel.Show(m, m.currentView)
 }
 
 func (m *Model) ScrollHelpUp(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.helpScrollY > 0 {
-		m.helpScrollY--
-	}
-	return m, nil
+	return m, m.helpViewModel.HandleScrollUp()
 }
 
 func (m *Model) ScrollHelpDown(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	// Will be calculated based on help content height
-	// For now, just increment
-	m.helpScrollY++
-	return m, nil
+	return m, m.helpViewModel.HandleScrollDown()
 }
 
 func (m *Model) BackFromHelp(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = m.previousView
-	m.helpScrollY = 0
-	return m, nil
+	return m, m.helpViewModel.HandleBack(m)
 }
 
 func (m *Model) CmdPause(_ tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -111,6 +111,7 @@ type Model struct {
 	dindProcessListViewModel     DindProcessListViewModel
 	imageListViewModel           ImageListViewModel
 	fileContentViewModel         FileContentViewModel
+	helpViewModel                HelpViewModel
 
 	// Docker images state
 	dockerImages        []models.DockerImage
@@ -213,10 +214,6 @@ type Model struct {
 	helpViewHandlers        []KeyConfig
 	commandExecKeymap       map[string]KeyHandler
 	commandExecHandlers     []KeyConfig
-
-	// Help view state
-	previousView ViewType
-	helpScrollY  int
 
 	// Command-line mode state
 	commandMode        bool

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -635,10 +635,7 @@ func (m *Model) executeCommand() (tea.Model, tea.Cmd) {
 			m.err = fmt.Errorf("%s", helpText)
 			return m, nil
 		}
-		m.previousView = m.currentView
-		m.currentView = HelpView
-		m.helpScrollY = 0
-		return m, nil
+		return m, m.helpViewModel.Show(m, m.currentView)
 
 	case "set": // TODO: deprecate this
 		// Handle set commands (e.g., :set showAll)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -308,7 +308,7 @@ func (m *Model) viewBody(availableHeight int) string {
 	case InspectView:
 		return m.renderInspectView(availableHeight)
 	case HelpView:
-		return m.renderHelpView(availableHeight)
+		return m.helpViewModel.render(m, availableHeight)
 	case CommandExecutionView:
 		return m.commandExecutionViewModel.render(m)
 	default:

--- a/internal/ui/view_command_execution.go
+++ b/internal/ui/view_command_execution.go
@@ -16,13 +16,14 @@ import (
 )
 
 type CommandExecutionViewModel struct {
-	cmd       *exec.Cmd
-	output    []string
-	scrollY   int
-	done      bool
-	exitCode  int
-	cmdString string
-	reader    *bufio.Reader
+	cmd          *exec.Cmd
+	output       []string
+	scrollY      int
+	done         bool
+	exitCode     int
+	cmdString    string
+	reader       *bufio.Reader
+	previousView ViewType
 }
 
 func (m *CommandExecutionViewModel) render(model *Model) string {
@@ -147,13 +148,13 @@ func (m *CommandExecutionViewModel) HandleBack(model *Model) tea.Cmd {
 	}
 
 	// Go back to previous view
-	model.currentView = model.previousView
+	model.currentView = m.previousView
 	model.loading = true
 
 	// TODO: CommandExecutionModelView でここを管理するのは微妙｡refresh してもらう旨だけ､メッセージ送ればよろしいかもしれず｡
 
 	// Reload data for the previous view
-	switch model.previousView {
+	switch m.previousView {
 	case ComposeProcessListView:
 		return loadProcesses(model.dockerClient, model.projectName, model.composeProcessListViewModel.showAll)
 	case DockerContainerListView:
@@ -237,7 +238,7 @@ func executeContainerCommand(client *docker.Client, containerID string, operatio
 }
 
 func (m *CommandExecutionViewModel) ExecuteContainerCommand(model *Model, previousView ViewType, containerID string, operation string) tea.Cmd {
-	model.previousView = previousView
+	m.previousView = previousView
 	model.currentView = CommandExecutionView
 	m.output = []string{}
 	m.scrollY = 0
@@ -248,7 +249,7 @@ func (m *CommandExecutionViewModel) ExecuteContainerCommand(model *Model, previo
 }
 
 func (m *CommandExecutionViewModel) ExecuteComposeCommand(model *Model, operation string) tea.Cmd {
-	model.previousView = model.currentView
+	m.previousView = model.currentView
 	model.currentView = CommandExecutionView
 	m.output = []string{}
 	m.scrollY = 0

--- a/internal/ui/view_help.go
+++ b/internal/ui/view_help.go
@@ -4,10 +4,16 @@ import (
 	"fmt"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
-func (m *Model) renderHelpView(availableHeight int) string {
+type HelpViewModel struct {
+	scrollY      int
+	previousView ViewType
+}
+
+func (m *HelpViewModel) render(model *Model, availableHeight int) string {
 	var s strings.Builder
 
 	// Get key configurations based on previous view
@@ -16,43 +22,43 @@ func (m *Model) renderHelpView(availableHeight int) string {
 
 	switch m.previousView {
 	case ComposeProcessListView:
-		configs = m.processListViewHandlers
+		configs = model.processListViewHandlers
 		viewName = "Compose Process List"
 	case LogView:
-		configs = m.logViewHandlers
+		configs = model.logViewHandlers
 		viewName = "Log View"
 	case DindProcessListView:
-		configs = m.dindListViewHandlers
+		configs = model.dindListViewHandlers
 		viewName = "Docker in Docker"
 	case TopView:
-		configs = m.topViewHandlers
+		configs = model.topViewHandlers
 		viewName = "Process Info"
 	case StatsView:
-		configs = m.statsViewHandlers
+		configs = model.statsViewHandlers
 		viewName = "Container Stats"
 	case ComposeProjectListView:
-		configs = m.projectListViewHandlers
+		configs = model.projectListViewHandlers
 		viewName = "Project List"
 	case DockerContainerListView:
-		configs = m.dockerListViewHandlers
+		configs = model.dockerListViewHandlers
 		viewName = "Docker Containers"
 	case ImageListView:
-		configs = m.imageListViewHandlers
+		configs = model.imageListViewHandlers
 		viewName = "Docker Images"
 	case NetworkListView:
-		configs = m.networkListViewHandlers
+		configs = model.networkListViewHandlers
 		viewName = "Docker Networks"
 	case VolumeListView:
-		configs = m.volumeListViewHandlers
+		configs = model.volumeListViewHandlers
 		viewName = "Docker Volumes"
 	case FileBrowserView:
-		configs = m.fileBrowserHandlers
+		configs = model.fileBrowserHandlers
 		viewName = "File Browser"
 	case FileContentView:
-		configs = m.fileContentHandlers
+		configs = model.fileContentHandlers
 		viewName = "File Content"
 	case InspectView:
-		configs = m.inspectViewHandlers
+		configs = model.inspectViewHandlers
 		viewName = "Inspect"
 	}
 
@@ -80,18 +86,18 @@ func (m *Model) renderHelpView(availableHeight int) string {
 	if maxScroll < 0 {
 		maxScroll = 0
 	}
-	if m.helpScrollY > maxScroll {
-		m.helpScrollY = maxScroll
+	if m.scrollY > maxScroll {
+		m.scrollY = maxScroll
 	}
 
 	// Render key bindings
 	visibleConfigs := configs
-	if m.helpScrollY > 0 && m.helpScrollY < len(configs) {
-		endIdx := m.helpScrollY + visibleLines - 5
+	if m.scrollY > 0 && m.scrollY < len(configs) {
+		endIdx := m.scrollY + visibleLines - 5
 		if endIdx > len(configs) {
 			endIdx = len(configs)
 		}
-		visibleConfigs = configs[m.helpScrollY:endIdx]
+		visibleConfigs = configs[m.scrollY:endIdx]
 	}
 
 	for _, config := range visibleConfigs {
@@ -129,4 +135,29 @@ func (m *Model) renderHelpView(availableHeight int) string {
 	s.WriteString(footer)
 
 	return s.String()
+}
+
+func (m *HelpViewModel) Show(model *Model, previousView ViewType) tea.Cmd {
+	m.previousView = previousView
+	model.currentView = HelpView
+	m.scrollY = 0
+	return nil
+}
+
+func (m *HelpViewModel) HandleScrollUp() tea.Cmd {
+	if m.scrollY > 0 {
+		m.scrollY--
+	}
+	return nil
+}
+
+func (m *HelpViewModel) HandleScrollDown() tea.Cmd {
+	m.scrollY++
+	return nil
+}
+
+func (m *HelpViewModel) HandleBack(model *Model) tea.Cmd {
+	model.currentView = m.previousView
+	m.scrollY = 0
+	return nil
 }


### PR DESCRIPTION
## Summary
- Refactored `view_help.go` to use the ViewModel pattern for better separation of concerns
- Created `HelpViewModel` struct to manage help view state and rendering
- Updated all references throughout the codebase to use the new ViewModel

## Changes
- Added `HelpViewModel` struct with:
  - `scrollY` field for scroll position
  - `previousView` field to track where to return
  - `render()` method for view rendering
  - `Show()`, `HandleScrollUp/Down()`, and `HandleBack()` methods
- Updated `CommandExecutionViewModel` to manage its own `previousView` field
- Removed `previousView` and `helpScrollY` from main `Model` struct
- Updated all keyhandlers and view references to use the new ViewModel methods

## Test plan
- [x] Run existing tests to ensure no regressions
- [ ] Manually test help view functionality:
  - [ ] Open help with `?` key from different views
  - [ ] Scroll up/down in help view
  - [ ] Return to previous view with `q` or `Esc`
  - [ ] Verify help content is displayed correctly

🤖 Generated with [Claude Code](https://claude.ai/code)