### PR TITLE
refactor: add StatsViewModel following established pattern

### DIFF
--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -218,9 +218,7 @@ func (m *Model) CmdToggleAll(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) ShowStatsView(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = StatsView
-	m.loading = true
-	return m, loadStats(m.dockerClient)
+	return m, m.statsViewModel.Show(m)
 }
 
 func (m *Model) CmdTop(_ tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -113,6 +113,7 @@ type Model struct {
 	fileContentViewModel         FileContentViewModel
 	helpViewModel                HelpViewModel
 	networkListViewModel         NetworkListViewModel
+	statsViewModel               StatsViewModel
 
 	// Docker images state
 	dockerImages        []models.DockerImage
@@ -148,9 +149,6 @@ type Model struct {
 	// Top view state
 	topOutput  string
 	topService string
-
-	// Stats view state
-	stats []ContainerStats
 
 	// Search state
 	searchMode       bool

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -153,7 +153,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			return m, nil
 		}
-		m.stats = msg.stats
+		m.statsViewModel.Loaded(msg.stats)
 		m.err = nil
 		return m, nil
 
@@ -290,7 +290,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case TopView:
 			return m, loadTop(m.dockerClient, m.projectName, m.topService)
 		case StatsView:
-			return m, loadStats(m.dockerClient)
+			return m, m.statsViewModel.HandleRefresh(m)
 		case ComposeProjectListView:
 			return m, loadProjects(m.dockerClient)
 		case DockerContainerListView:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -290,7 +290,7 @@ func (m *Model) viewBody(availableHeight int) string {
 	case TopView:
 		return m.renderTopView(availableHeight)
 	case StatsView:
-		return m.renderStatsView(availableHeight)
+		return m.statsViewModel.render(m, availableHeight)
 	case ComposeProjectListView:
 		return m.composeProjectListViewModel.render(m, availableHeight)
 	case DockerContainerListView:


### PR DESCRIPTION
## Summary
- Refactored stats view to use StatsViewModel pattern for better separation of concerns
- Fixed CPU percentage parsing bug where code was checking `*new(float64)` instead of the actual parsed value
- Follows the established ViewModel pattern used in other views

## Changes
- Created `StatsViewModel` struct with `stats` field
- Added methods: `render()`, `Show()`, `HandleRefresh()`, `HandleBack()`, and `Loaded()`
- Moved stats-related state from Model to StatsViewModel
- Updated all references in keyhandler.go, update.go, and view.go
- Fixed CPU percentage parsing to properly store and check the parsed value

## Test plan
- [x] Ran existing tests - all pass
- [x] Manually tested stats view functionality
- [x] Verified CPU percentage coloring works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)