### PR TITLE
fix: resolve release workflow failures and deprecation warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v6
       with:
         distribution: goreleaser
-        version: latest
+        version: ~> v2
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,7 @@ builds:
 archives:
   - id: dcv
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    format: tar.gz
     format_overrides:
       - goos: windows
         format: zip
@@ -58,16 +59,3 @@ brews:
       system "#{bin}/dcv", "--version"
     install: |
       bin.install "dcv"
-
-dockers:
-  - image_templates:
-      - "ghcr.io/tokuhirom/dcv:{{ .Tag }}"
-      - "ghcr.io/tokuhirom/dcv:latest"
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"


### PR DESCRIPTION
## Summary
- Fix release workflow that was failing on v0.0.3
- Address deprecation warnings in GitHub Actions

## Root Cause
The release workflow was failing because:
1. GoReleaser tried to build Docker images but no Dockerfile exists in the repository
2. Using 'latest' version for goreleaser-action caused deprecation warning

## Changes
- ✅ Specify explicit GoReleaser version (`~> v2`) instead of `latest`
- ✅ Remove Docker image building configuration from `.goreleaser.yml`
- ✅ Add explicit `format: tar.gz` to archives section

## Testing
- All tests pass locally (`make test`)
- Code formatted with `make fmt`

## Impact
This fix will allow releases to complete successfully and eliminates deprecation warnings.

🤖 Generated with [Claude Code](https://claude.ai/code)