### PR TITLE
feat: add page navigation to File Content view

### DIFF
--- a/internal/ui/keyhandler_navigation.go
+++ b/internal/ui/keyhandler_navigation.go
@@ -138,6 +138,8 @@ func (m *Model) CmdPageUp(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.logViewModel.HandlePageUp(m)
 	case InspectView:
 		return m, m.inspectViewModel.HandlePageUp(m)
+	case FileContentView:
+		return m, m.fileContentViewModel.HandlePageUp(m.Height)
 	default:
 		slog.Info("PageUp not supported in current view",
 			slog.String("view", m.currentView.String()))
@@ -151,6 +153,8 @@ func (m *Model) CmdPageDown(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.logViewModel.HandlePageDown(m)
 	case InspectView:
 		return m, m.inspectViewModel.HandlePageDown(m)
+	case FileContentView:
+		return m, m.fileContentViewModel.HandlePageDown(m.Height)
 	default:
 		slog.Info("PageDown not supported in current view",
 			slog.String("view", m.currentView.String()))

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -188,6 +188,8 @@ func (m *Model) initializeKeyHandlers() {
 	m.fileContentHandlers = []KeyConfig{
 		{[]string{"up", "k"}, "scroll up", m.CmdUp},
 		{[]string{"down", "j"}, "scroll down", m.CmdDown},
+		{[]string{"pgup"}, "page up", m.CmdPageUp},
+		{[]string{"pgdown", " "}, "page down", m.CmdPageDown},
 		{[]string{"G"}, "go to end", m.CmdGoToEnd},
 		{[]string{"g"}, "go to beginning", m.CmdGoToBeginning},
 		{[]string{"esc"}, "back", m.CmdBack},

--- a/internal/ui/view_file_content.go
+++ b/internal/ui/view_file_content.go
@@ -104,6 +104,29 @@ func (m *FileContentViewModel) HandleGoToEnd(height int) tea.Cmd {
 	return nil
 }
 
+func (m *FileContentViewModel) HandlePageUp(height int) tea.Cmd {
+	pageSize := height - 5
+	if m.scrollY > pageSize {
+		m.scrollY -= pageSize
+	} else {
+		m.scrollY = 0
+	}
+	return nil
+}
+
+func (m *FileContentViewModel) HandlePageDown(height int) tea.Cmd {
+	lines := strings.Split(m.content, "\n")
+	maxScroll := len(lines) - (height - 5)
+	pageSize := height - 5
+
+	if m.scrollY+pageSize < maxScroll {
+		m.scrollY += pageSize
+	} else if maxScroll > 0 {
+		m.scrollY = maxScroll
+	}
+	return nil
+}
+
 func (m *FileContentViewModel) HandleBack(model *Model) tea.Cmd {
 	model.SwitchToPreviousView()
 	m.content = ""

--- a/internal/ui/view_file_content_test.go
+++ b/internal/ui/view_file_content_test.go
@@ -339,3 +339,73 @@ func TestFileContentViewModel_EmptyContent(t *testing.T) {
 }
 
 // Test message types are already defined in model.go
+
+func TestFileContentViewModel_PageNavigation(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialScrollY int
+		content        string
+		height         int
+		action         string
+		expectedScroll int
+	}{
+		{
+			name:           "page up from middle",
+			initialScrollY: 20,
+			content:        strings.Repeat("Line\n", 100),
+			height:         15, // pageSize = 15 - 5 = 10
+			action:         "pageup",
+			expectedScroll: 10,
+		},
+		{
+			name:           "page up from near top",
+			initialScrollY: 5,
+			content:        strings.Repeat("Line\n", 100),
+			height:         15, // pageSize = 10
+			action:         "pageup",
+			expectedScroll: 0,
+		},
+		{
+			name:           "page down from start",
+			initialScrollY: 0,
+			content:        strings.Repeat("Line\n", 100),
+			height:         15, // pageSize = 10
+			action:         "pagedown",
+			expectedScroll: 10,
+		},
+		{
+			name:           "page down near end",
+			initialScrollY: 85,
+			content:        strings.TrimSuffix(strings.Repeat("Line\n", 100), "\n"),
+			height:         15, // pageSize = 10, maxScroll = 100 - 10 = 90
+			action:         "pagedown",
+			expectedScroll: 90,
+		},
+		{
+			name:           "page down at end",
+			initialScrollY: 90,
+			content:        strings.TrimSuffix(strings.Repeat("Line\n", 100), "\n"),
+			height:         15,
+			action:         "pagedown",
+			expectedScroll: 90, // stays at max
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vm := &FileContentViewModel{
+				content: tt.content,
+				scrollY: tt.initialScrollY,
+			}
+
+			switch tt.action {
+			case "pageup":
+				vm.HandlePageUp(tt.height)
+			case "pagedown":
+				vm.HandlePageDown(tt.height)
+			}
+
+			assert.Equal(t, tt.expectedScroll, vm.scrollY)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implements page navigation support (PgUp/PgDn/Space) for the File Content view
- Improves navigation of large files by allowing page-wise scrolling
- Closes #232

## Changes
- Added `HandlePageUp()` and `HandlePageDown()` methods to `FileContentViewModel`
- Page size calculated as viewport height minus header/footer space (height - 5)
- Updated navigation key handlers to support FileContentView
- Added keybindings: `pgup` for page up, `pgdown` and `space` for page down
- Properly handles boundaries to prevent scrolling beyond content

## Test plan
- [x] Unit tests added for page navigation methods
- [x] Tested with files of various sizes
- [x] Verified boundary conditions (top/bottom of file)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)