### PR TITLE
fix: remove auto-commit from screenshots workflow for protected main branch

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -17,7 +17,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     
     steps:
@@ -44,17 +44,8 @@ jobs:
           echo "changed=true" >> $GITHUB_OUTPUT
         fi
     
-    - name: Commit and push screenshots (main branch only)
-      if: github.ref == 'refs/heads/main' && steps.check_changes.outputs.changed == 'true'
-      run: |
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git add docs/screenshots/
-        git commit -m "chore: update screenshots [skip ci]"
-        git push
-    
-    - name: Upload screenshots as artifacts (PR)
-      if: github.event_name == 'pull_request'
+    - name: Upload screenshots as artifacts
+      if: steps.check_changes.outputs.changed == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: screenshots


### PR DESCRIPTION
## Summary
- Removed auto-commit functionality from screenshots workflow
- Always uploads artifacts when changes are detected
- Reverted permissions to read-only for contents

## Problem
The main branch has protection rules that prevent direct pushes, even from GitHub Actions. The workflow was failing with exit code 128 when trying to push commits.

## Solution
Since we can't push directly to a protected main branch, the workflow now:
1. Generates screenshots as before
2. Uploads them as artifacts instead of committing
3. No longer attempts to push to main branch

This ensures the workflow succeeds while respecting branch protection rules. Screenshot updates can be handled manually via PR if needed.

## Test plan
- [x] Workflow syntax is valid
- [x] Tests pass locally
- [ ] Workflow will complete successfully on main branch after merge
- [ ] Screenshots will be available as artifacts

🤖 Generated with [Claude Code](https://claude.ai/code)