### PR TITLE
fix: change file browser shortcut from 'b' to 'f'

### DIFF
--- a/internal/tui/views/compose_process_list.go
+++ b/internal/tui/views/compose_process_list.go
@@ -136,7 +136,7 @@ func (v *ComposeProcessListView) setupKeyHandlers() {
 			}
 			return nil
 
-		case 'b':
+		case 'f':
 			// Browse files
 			if row > 0 && row <= len(v.composeContainers) {
 				container := v.composeContainers[row-1]

--- a/internal/tui/views/docker_container_list.go
+++ b/internal/tui/views/docker_container_list.go
@@ -136,7 +136,7 @@ func (v *DockerContainerListView) setupKeyHandlers() {
 			}
 			return nil
 
-		case 'b':
+		case 'f':
 			// Browse files
 			if row > 0 && row <= len(v.containers) {
 				container := v.containers[row-1]


### PR DESCRIPTION
## Summary
- Changed keyboard shortcut for file browsing from 'b' to 'f' in Docker container list view
- Changed keyboard shortcut for file browsing from 'b' to 'f' in Compose process list view
- 'b' shortcut remains unchanged in project list view where it is used for Build operation

## Motivation
The 'f' key is more intuitive for "file" browsing operations, and 'b' was causing confusion with the Build operation in project list view.

## Test plan
- [x] All tests pass
- [x] Code formatted with `make fmt`
- [x] Linter checks pass with `make lint`

🤖 Generated with [Claude Code](https://claude.ai/code)