### PR TITLE
fix: log view filter+scroll ANSI corruption and review follow-ups

### DIFF
--- a/internal/ui/container_search.go
+++ b/internal/ui/container_search.go
@@ -73,7 +73,6 @@ func (m *ContainerSearchViewModel) IsSearchActive() bool {
 	return m.searchMode
 }
 
-// HasSearchResults returns true if there are search results
 // IsCurrentSearchLine reports whether rowIndex is the active search result.
 func (m *ContainerSearchViewModel) IsCurrentSearchLine(rowIndex int) bool {
 	return len(m.searchResults) > 0 &&
@@ -81,6 +80,7 @@ func (m *ContainerSearchViewModel) IsCurrentSearchLine(rowIndex int) bool {
 		m.searchResults[m.currentSearchIdx] == rowIndex
 }
 
+// HasSearchResults returns true if there are search results
 func (m *ContainerSearchViewModel) HasSearchResults() bool {
 	return len(m.searchResults) > 0
 }

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -7,6 +7,10 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
+// SearchViewModel holds search state shared by views that match per line.
+// LogViewModel stores per-occurrence positions in logSearchMatches instead and
+// leaves searchResults nil, so HasSearchResults / IsCurrentSearchLine here are
+// not meaningful for the log view — use the log-specific helpers.
 type SearchViewModel struct {
 	searchMode       bool
 	searchText       string

--- a/internal/ui/view_log.go
+++ b/internal/ui/view_log.go
@@ -7,7 +7,6 @@ import (
 	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/mattn/go-runewidth"
 
 	"github.com/tokuhirom/dcv/internal/docker"
@@ -80,39 +79,6 @@ func wrapLineSegments(line string, width int) []wrappedSegment {
 	return segments
 }
 
-// sliceByDisplayWidth returns the portion of s starting at display column start,
-// spanning at most maxWidth display columns.
-func sliceByDisplayWidth(s string, start, maxWidth int) string {
-	if maxWidth <= 0 {
-		return ""
-	}
-	if start < 0 {
-		start = 0
-	}
-
-	var b strings.Builder
-	pos := 0
-	outWidth := 0
-	for i := 0; i < len(s); {
-		r, size := utf8.DecodeRuneInString(s[i:])
-		rw := runewidth.RuneWidth(r)
-		lineEnd := pos + rw
-
-		if pos >= start && outWidth < maxWidth {
-			if outWidth+rw > maxWidth {
-				break
-			}
-			b.WriteRune(r)
-			outWidth += rw
-		}
-
-		pos = lineEnd
-		i += size
-	}
-
-	return b.String()
-}
-
 // displayWidthToByteIndex returns the byte index at the given display column.
 func displayWidthToByteIndex(s string, targetCol int) int {
 	if targetCol <= 0 {
@@ -129,13 +95,6 @@ func displayWidthToByteIndex(s string, targetCol int) int {
 		i += size
 	}
 	return len(s)
-}
-
-func (m *LogViewModel) formatLogLine(line string, effectiveWidth int) string {
-	if m.WrapText() {
-		return lipgloss.NewStyle().Width(effectiveWidth).Render(line)
-	}
-	return sliceByDisplayWidth(line, m.logScrollX, effectiveWidth)
 }
 
 func (m *LogViewModel) logLineSegments(line string, effectiveWidth int) []wrappedSegment {
@@ -397,10 +356,6 @@ func (m *LogViewModel) renderWrapped(model *Model, logsToDisplay []string, visib
 	endIdx := 0
 
 	for i, line := range logsToDisplay {
-		if m.filterMode && m.filterText != "" {
-			line = m.highlightFilterMatch(line, searchMatchStyle)
-		}
-
 		for _, seg := range wrapLineSegments(line, effectiveWidth) {
 			if skip > 0 {
 				skip--
@@ -415,10 +370,7 @@ func (m *LogViewModel) renderWrapped(model *Model, logsToDisplay []string, visib
 			}
 			endIdx = i + 1
 
-			displayLine := line[seg.startByte:seg.endByte]
-			if m.searchText != "" && !m.searchMode {
-				displayLine = m.highlightSegment(line, i, seg)
-			}
+			displayLine := m.renderSegment(line, i, seg)
 
 			if m.isCurrentMatchOnSegment(i, seg) {
 				s.WriteString("> ")
@@ -457,19 +409,8 @@ func (m *LogViewModel) renderNoWrap(model *Model, logsToDisplay []string, visibl
 
 	for i := startIdx; i < endIdx; i++ {
 		line := logsToDisplay[i]
-
-		if m.filterMode && m.filterText != "" {
-			line = m.highlightFilterMatch(line, searchMatchStyle)
-			s.WriteString("  ")
-			s.WriteString(m.formatLogLine(line, effectiveWidth) + ResetAll + "\n")
-			continue
-		}
-
 		for _, seg := range m.logLineSegments(line, effectiveWidth) {
-			displayLine := line[seg.startByte:seg.endByte]
-			if m.searchText != "" && !m.searchMode {
-				displayLine = m.highlightSegment(line, i, seg)
-			}
+			displayLine := m.renderSegment(line, i, seg)
 
 			if m.isCurrentMatchOnSegment(i, seg) {
 				s.WriteString("> ")
@@ -619,6 +560,19 @@ func (m *LogViewModel) scrollToSearchMatch(model *Model, match logSearchMatch) {
 	}
 }
 
+// renderSegment returns the display text for a single segment, applying
+// filter or search highlighting where appropriate. Operating on raw bytes
+// here avoids slicing through ANSI escapes added by highlighting helpers.
+func (m *LogViewModel) renderSegment(fullLine string, lineIndex int, seg wrappedSegment) string {
+	if m.filterMode && m.filterText != "" {
+		return m.highlightFilterSegment(fullLine, seg)
+	}
+	if m.searchText != "" && !m.searchMode {
+		return m.highlightSegment(fullLine, lineIndex, seg)
+	}
+	return fullLine[seg.startByte:seg.endByte]
+}
+
 func (m *LogViewModel) highlightSegment(fullLine string, lineIndex int, seg wrappedSegment) string {
 	text := fullLine[seg.startByte:seg.endByte]
 	if m.searchText == "" {
@@ -667,40 +621,47 @@ func (m *LogViewModel) matchRangesOnLine(line string, lineIndex int) []logSearch
 	return ranges
 }
 
-func (m *LogViewModel) highlightFilterMatch(line string, style lipgloss.Style) string {
+// highlightFilterSegment highlights filter matches within a single display
+// segment. Matches are computed against fullLine (raw, ANSI-free) and rendered
+// only for the portion that overlaps seg, so callers can slice safely without
+// risk of cutting an ANSI escape in half.
+func (m *LogViewModel) highlightFilterSegment(fullLine string, seg wrappedSegment) string {
+	text := fullLine[seg.startByte:seg.endByte]
 	if m.filterText == "" {
-		return line
+		return text
 	}
 
-	// Simple case-insensitive string search for filter
 	searchStr := strings.ToLower(m.filterText)
-	lineToSearch := strings.ToLower(line)
-
-	// Find all occurrences
-	var result strings.Builder
-	lastEnd := 0
+	lineToSearch := strings.ToLower(fullLine)
 	searchLen := len(searchStr)
 
-	for lastEnd < len(line) {
-		idx := strings.Index(lineToSearch[lastEnd:], searchStr)
+	var result strings.Builder
+	lastEnd := 0
+	scan := 0
+	for scan < len(fullLine) {
+		idx := strings.Index(lineToSearch[scan:], searchStr)
 		if idx == -1 {
-			// No more matches, append the rest
-			result.WriteString(line[lastEnd:])
 			break
 		}
-
-		// Found a match
-		matchStart := lastEnd + idx
+		matchStart := scan + idx
 		matchEnd := matchStart + searchLen
+		scan = matchEnd
 
-		// Append text before the match
-		result.WriteString(line[lastEnd:matchStart])
-		// Append highlighted match
-		result.WriteString(style.Render(line[matchStart:matchEnd]))
-		// Move past this match
-		lastEnd = matchEnd
+		if matchEnd <= seg.startByte || matchStart >= seg.endByte {
+			continue
+		}
+
+		relStart := max(matchStart-seg.startByte, 0)
+		relEnd := min(matchEnd-seg.startByte, len(text))
+		if relStart > lastEnd {
+			result.WriteString(text[lastEnd:relStart])
+		}
+		result.WriteString(searchMatchStyle.Render(text[relStart:relEnd]))
+		lastEnd = relEnd
 	}
-
+	if lastEnd < len(text) {
+		result.WriteString(text[lastEnd:])
+	}
 	return result.String()
 }
 

--- a/internal/ui/view_log_test.go
+++ b/internal/ui/view_log_test.go
@@ -478,8 +478,8 @@ func TestLogView_Search(t *testing.T) {
 		cmd := model.logViewModel.HandleNextSearchResult(model)
 		assert.Nil(t, cmd)
 		assert.Equal(t, 1, model.logViewModel.currentSearchIdx)
-		// Scrolls toward line 3, clamped to maxScroll for the viewport
-		assert.GreaterOrEqual(t, model.logViewModel.logScrollY, 1)
+		// targetLine - Height/2 + 3 = 3 - 4 + 3 = 2, clamped to maxScroll=1.
+		assert.Equal(t, 1, model.logViewModel.logScrollY)
 
 		// Wrap around
 		cmd = model.logViewModel.HandleNextSearchResult(model)
@@ -870,13 +870,6 @@ func TestLogView_WrappedSearchMarker(t *testing.T) {
 	assert.NotContains(t, lines[0], "> ERROR first", "first wrapped row should not be marked when second match is current")
 }
 
-func TestSliceByDisplayWidth(t *testing.T) {
-	line := strings.Repeat("a", 10) + strings.Repeat("b", 100)
-
-	assert.Equal(t, strings.Repeat("a", 10), sliceByDisplayWidth(line, 0, 10))
-	assert.Equal(t, strings.Repeat("b", 10), sliceByDisplayWidth(line, 10, 10))
-}
-
 func TestLogView_WrapAndHorizontalScroll(t *testing.T) {
 	longLine := strings.Repeat("a", 10) + strings.Repeat("b", 100)
 	wrapLine := strings.Repeat("A", 120)
@@ -952,6 +945,49 @@ func TestLogView_WrapAndHorizontalScroll(t *testing.T) {
 		lines := strings.Split(strings.TrimRight(result, "\n"), "\n")
 		assert.Greater(t, len(lines), 1, "wrapped long line should span multiple rows")
 	})
+}
+
+// TestLogView_FilterHorizontalScroll guards against the previous bug where the
+// nowrap path would highlight first and then slice — the slice would cut
+// through ANSI escape sequences, leaving stray characters in the output.
+func TestLogView_FilterHorizontalScroll(t *testing.T) {
+	// "MATCH" starts at byte offset 50; with scrollX=40 and width=82
+	// (effectiveWidth=80) the visible slice spans bytes 40..120 — both the
+	// pre-match and the match itself land inside the window.
+	line := strings.Repeat("a", 50) + "MATCH" + strings.Repeat("b", 100)
+
+	model := &Model{
+		logViewModel: LogViewModel{
+			logs:       []string{line},
+			logScrollX: 40,
+			LogReaderManager: LogReaderManager{
+				wrapText: false,
+			},
+			FilterViewModel: FilterViewModel{
+				filterMode:   true,
+				filterText:   "MATCH",
+				filteredLogs: []string{line},
+			},
+		},
+		width:  82,
+		Height: 10,
+	}
+
+	rendered := model.logViewModel.render(model, 10)
+	plain := stripANSI(rendered)
+	content := strings.Split(plain, "\n")[0]
+
+	// Sanity: the slice begins at column 40 (still in the leading 'a' block)
+	// and includes "MATCH" followed by the trailing 'b' block.
+	assert.True(t, strings.HasPrefix(content, "  "+strings.Repeat("a", 10)+"MATCH"),
+		"visible slice should start at scrollX and include the match, got %q", content)
+	assert.Contains(t, content, "MATCH")
+
+	// The filter highlight wraps "MATCH" with ANSI escapes. With the fix,
+	// those escapes appear intact around the match within the slice.
+	highlighted := searchMatchStyle.Render("MATCH")
+	assert.Contains(t, rendered, highlighted,
+		"filter highlight must survive horizontal slicing")
 }
 
 func TestLogView_Integration(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-ups from the review of #370 (now merged). Three concrete fixes plus test/doc cleanup.

- **Filter + horizontal scroll no longer corrupts ANSI escapes.** Previously, `renderNoWrap` called `highlightFilterMatch(line, ...)` to wrap matches in lipgloss escape sequences, then passed the highlighted string to `sliceByDisplayWidth` which cuts on raw bytes — slicing through `\x1b[...m` would leak stray characters into the output when `logScrollX > 0`. The same shape of bug also existed in `renderWrapped` via `wrapLineSegments`. Both render paths now go through a new `renderSegment` helper that highlights *within* a pre-computed display segment using the raw line, so segment boundaries never split an escape sequence.
- **Restored `HasSearchResults` doc comment** in `container_search.go`. After the merge it had drifted above `IsCurrentSearchLine`.
- **Documented `SearchViewModel` divergence** for `LogViewModel`: log view keeps the embedded `searchResults` nil and uses `logSearchMatches` instead, so the base methods aren't meaningful there.
- **Tightened a relaxed test assertion** (`HandleNextSearchResult`) — now asserts the concrete clamped `logScrollY=1` rather than `GreaterOrEqual(..., 1)`.
- **Added a regression test** for filter + nowrap + horizontal scroll that verifies the filter highlight survives slicing.

Removed `sliceByDisplayWidth` and `formatLogLine` along with the dead `TestSliceByDisplayWidth`, since the unified `renderSegment` path makes them unused. `logLineSegments` (which is ANSI-unaware but always operates on raw lines) covers both wrap and nowrap segmenting.

## Test plan

- [x] `make fmt`
- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass
- [x] New `TestLogView_FilterHorizontalScroll` exercises the previously broken path

🤖 Generated with [Claude Code](https://claude.com/claude-code)